### PR TITLE
Boot: Fix early page stack allocation

### DIFF
--- a/Boot/xnldr.cpp
+++ b/Boot/xnldr.cpp
@@ -268,7 +268,7 @@ EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemTable) {
 
 	const size_t EARLY_PAGE_STACK_SIZE = 1024 * 1024;
 	EFI_PHYSICAL_ADDRESS earlyPhyPageStack = 0;
-	if (!(SystemTable->BootServices->AllocatePages(AllocateAnyPages, EfiLoaderData, EARLY_PAGE_STACK_SIZE / EFI_PAGE_SIZE, (EFI_PHYSICAL_ADDRESS*)earlyPhyPageStack))) 
+	if ((SystemTable->BootServices->AllocatePages(AllocateAnyPages, EfiLoaderData, EARLY_PAGE_STACK_SIZE / EFI_PAGE_SIZE, (EFI_PHYSICAL_ADDRESS*)&earlyPhyPageStack))) 
 		XEGuiPrint("Early Page Stack: allocation failed.....\n");
 
 	/*Status = gSystemTable->BootServices->SetWatchdogTimer(0, 0, 0, 0);


### PR DESCRIPTION
Quite self explanatory, it fixes the early page stack allocation done by the OS loader