### PR TITLE
prevent buffer overflow in nslook and ping 

### DIFF
--- a/Process/nslook/main.cpp
+++ b/Process/nslook/main.cpp
@@ -46,7 +46,7 @@
 */
 int main(int argc, char* argv[]) {
 	printf("\n");
-	char* s = (char*)malloc(strlen(argv[1]));
+	char* s = (char*)malloc(strlen(argv[1])+1);
 	strcpy(s, argv[1]);
 	printf("Getting nameserver info for %s DNS Pack -> %d \n", s, sizeof(DNSPacket));
 	hostent* ent = gethostbyname(s);

--- a/Process/ping/main.cpp
+++ b/Process/ping/main.cpp
@@ -69,7 +69,7 @@ static uint16_t ICMPCalculateChecksum(char* payload, size_t len) {
 */
 int main(int argc, char* argv[]){
 	printf("\n");
-	char* s = (char*)malloc(strlen(argv[1]));
+	char* s = (char*)malloc(strlen(argv[1])+1);
 	strcpy(s, argv[1]);
 	
 	hostent* ent = gethostbyname(s);


### PR DESCRIPTION
closes issue #23 .
prevent buffer overflows by allocating space for null terminator