### PR TITLE
Free filename and buffer to prevent leaks

### DIFF
--- a/Process/cat/main.cpp
+++ b/Process/cat/main.cpp
@@ -89,4 +89,7 @@ int main(int argc, char* argv[]){
     if (read_bytes > 0) {
         printf("%s", buffer);
     }
+    free(filename);
+    free(buffer);
+    return 0;
 }


### PR DESCRIPTION
Added free() calls for filename and buffer to release allocated memory
closes #34 