### PR TITLE
calc-fixes

### DIFF
--- a/Process/Calculator/main.cpp
+++ b/Process/Calculator/main.cpp
@@ -171,7 +171,7 @@ void CalculatorProcess(CalculatorDisplay* calc) {
 	int num2 = atoi(calc->inputnum);
 	calc->num2 = num2;
 	int result = 0;
-	if (calc->num1 > 0) {
+	if (calc->operator_ != 0) {
 		int num1 = calc->num1;
 		switch (calc->operator_) {
 		case CALC_OPERATOR_ADD:
@@ -226,9 +226,9 @@ void CalculatorProcess(CalculatorDisplay* calc) {
 void CalcAddDigit(CalculatorDisplay* disp, int number){
 	if (number > 9)
 		return;
-	char num[1];
+	char num[16];
 	itoa_s(number, 10, num);
-	if (disp->inputidx == 1024)
+	if (disp->inputidx >= 1023)
 		return;
 	disp->inputnum[disp->inputidx] = num[0];
 	disp->inputidx++;


### PR DESCRIPTION
1) Changed the condition in CalculatorProcess from checking if the first operand is positive (calc->num1 > 0) to checking that an operator is set (calc->operator_ != 0). This allows calculations starting with zero or negative numbers (e.g. 0 + 5 or -5 + 10).

2) Enlarged the stack-allocated buffer num in CalcAddDigit from char num[1] to char num[16] to prevent itoa_s from writing out-of-bounds.

3) Enforced a capping check disp->inputidx >= 1023 in CalcAddDigit to reserve the last byte in the 1024-byte input buffer for the null terminator \0, avoiding reading past memory boundaries.