### PR TITLE
bugfix/net-and-shell-fixes

### DIFF
--- a/Kernel/Net/tcp.cpp
+++ b/Kernel/Net/tcp.cpp
@@ -85,7 +85,7 @@ uint16_t CalculateTCPChecksum(TCPCheckHeader* p, TCPHeader* h, void* d, size_t p
 	for (unsigned int i = 0; i < dwords; ++i) {
 		sum += ntohs(s[i]);
 		if (sum > 0xFFFF) 
-			sum = (sum >> 16) + (sum & 0xFFFFF);
+			sum = (sum >> 16) + (sum & 0xFFFF);
 	}
 
 	if (dwords * static_cast<uint64_t>(2) != payloadsz){
@@ -206,7 +206,7 @@ int AuTCPAcknowledge(AuVFSNode* nic, AuSocket* sock, IPv4Header* ippack, size_t 
 	checkhdr.protocol = IPV4_PROTOCOL_TCP;
 	checkhdr.tcpLen = htons(sizeof(TCPHeader));
 
-	tcppack->checksum = htons(CalculateTCPChecksum(&checkhdr, tcp, NULL, 0));
+	tcppack->checksum = htons(CalculateTCPChecksum(&checkhdr, tcppack, NULL, 0));
 	IPV4SendPacket(ipv4, nic);
 	SeTextOut("TCP-ACK Sent !! successfully \r\n");
 	kfree(ipv4);

--- a/Process/XEShell/main.cpp
+++ b/Process/XEShell/main.cpp
@@ -408,10 +408,12 @@ void XEShellProcessLine() {
 			_spawnable_process = false;
 		}
 
-		if (strstr(cmdBuf, "cd")) {
+		if (strncmp(cmdBuf, "cd ", 3) == 0 || strcmp(cmdBuf, "cd") == 0) {
 			char* path = cmdBuf + 2;
-			while (strstr(path, " "))
-				path++;
+			if (*path == ' ') {
+				while (*path == ' ')
+					path++;
+			}
 			XEShellCD(path);
 			printf("\n");
 			_spawnable_process = false;
@@ -422,8 +424,12 @@ void XEShellProcessLine() {
 			_spawnable_process = false;
 		}
 
-		if (strstr(cmdBuf, "echo")) {
+		if (strncmp(cmdBuf, "echo ", 5) == 0 || strcmp(cmdBuf, "echo") == 0) {
 			char* msg = cmdBuf + 4;
+			if (*msg == ' ') {
+				while (*msg == ' ')
+					msg++;
+			}
 			XEShellEcho(msg);
 			_spawnable_process = false;
 		}


### PR DESCRIPTION
1) Corrected a typo in CalculateTCPChecksum fold loop where a 20-bit mask (0xFFFFF) was used instead of 16-bit (0xFFFF), which failed to correctly fold the carry bit.
- Fixed AuTCPAcknowledge to calculate the outgoing packet's checksum based on the newly constructed acknowledgment header pointer instead of using the received packet's header pointer.

2) Replaced strstr-based command detection for "cd" and "echo" in XEShellProcessLine with explicit prefix and exact-match string comparisons (strncmp/strcmp). This prevents false matches where substring combinations (e.g. typing abcd) would mistakenly trigger those command handlers.
- Hardened post-command space skipping to cleanly isolate argument paths and messages.