### PR TITLE
feat(gcc): add Linux cross-compilation support and ARM64 stability fixes

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-windows-msvc:
     name: MSVC (Windows / x64)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -54,12 +54,10 @@ jobs:
         run: |
           Expand-Archive -Path Resources/nasmprops.zip -DestinationPath nasmprops -Force
           $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $customizationsPath = Join-Path $vsPath "MSBuild\Microsoft\VC\v170\BuildCustomizations"
-          if (-not (Test-Path $customizationsPath)) {
-            $customizationsPath = Join-Path $vsPath "MSBuild\Microsoft\VC\v160\BuildCustomizations"
-          }
+          $vcPath = Join-Path $vsPath "MSBuild\Microsoft\VC"
+          $customizationsPath = Get-ChildItem -Path $vcPath -Filter "BuildCustomizations" -Directory -Recurse | Select-Object -ExpandProperty FullName -First 1
           Copy-Item nasmprops\* -Destination $customizationsPath -Force -Recurse
 
       - name: Build Solution (Aurora.sln)
         run: |
-          msbuild Aurora.sln /p:Configuration=Debug /p:Platform=x64
+          msbuild Aurora.sln /p:Configuration=Debug /p:Platform=x64 /p:PlatformToolset=v143

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,64 @@
+name: XenevaOS Build Check (MSVC & GCC)
+
+on:
+  push:
+    branches: [ master, khrsgr ]
+  pull_request:
+    branches: [ master, khrsgr ]
+  workflow_dispatch:
+
+jobs:
+  build-linux-gcc:
+    name: GCC (Linux / ARM64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install Toolchains (GCC AArch64)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu make mtools dosfstools
+
+      - name: Build GNU-EFI (AArch64)
+        run: |
+          cd gnu-efi
+          make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu-
+
+      - name: Build Bootloader (BootAA64)
+        run: |
+          cd BootAA64
+          make
+
+      - name: Build Kernel (KernelAA64)
+        run: |
+          cd KernelAA64
+          make
+
+  build-windows-msvc:
+    name: MSVC (Windows / x64)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+
+      - name: Install NASM
+        uses: ilammy/setup-nasm@v1
+
+      - name: Setup NASM Customizations for MSBuild
+        shell: pwsh
+        run: |
+          Expand-Archive -Path Resources/nasmprops.zip -DestinationPath nasmprops -Force
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          $customizationsPath = Join-Path $vsPath "MSBuild\Microsoft\VC\v170\BuildCustomizations"
+          if (-not (Test-Path $customizationsPath)) {
+            $customizationsPath = Join-Path $vsPath "MSBuild\Microsoft\VC\v160\BuildCustomizations"
+          }
+          Copy-Item nasmprops\nasmprops\* -Destination $customizationsPath -Force -Recurse
+
+      - name: Build Solution (Aurora.sln)
+        run: |
+          msbuild Aurora.sln /p:Configuration=Debug /p:Platform=x64

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Build GNU-EFI (AArch64)
         run: |
+          git clone https://github.com/vathpela/gnu-efi gnu-efi
           cd gnu-efi
           make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu-
 
@@ -57,7 +58,7 @@ jobs:
           if (-not (Test-Path $customizationsPath)) {
             $customizationsPath = Join-Path $vsPath "MSBuild\Microsoft\VC\v160\BuildCustomizations"
           }
-          Copy-Item nasmprops\nasmprops\* -Destination $customizationsPath -Force -Recurse
+          Copy-Item nasmprops\* -Destination $customizationsPath -Force -Recurse
 
       - name: Build Solution (Aurora.sln)
         run: |

--- a/BootAA64/pe.cpp
+++ b/BootAA64/pe.cpp
@@ -84,6 +84,9 @@ void XEPELoadImage(void* filebuff) {
 		void* sect_addr = (void*)load_addr;
 		
 		size_t sectsz = sectionHeader[i].VirtualSize;
+		if (sectionHeader[i].SizeOfRawData > sectsz) {
+			sectsz = sectionHeader[i].SizeOfRawData;
+		}
 		size_t aligned_addr = load_addr & ~0xFFFULL;
 		int req_pages = (sectsz + (load_addr & 0xFFF)) / 4096 +
 			(((sectsz + (load_addr & 0xFFF)) % 4096) ? 1 : 0);

--- a/BootAA64/xnldr.cpp
+++ b/BootAA64/xnldr.cpp
@@ -128,6 +128,9 @@ MENU_ITEM MenuItem[] = {
  * @param SystemTable -- Pointer to EFI SYSTEM TABLE
  */
 int XEGetScreenResolutionMode(EFI_SYSTEM_TABLE* SystemTable) {
+#ifdef __TARGET_BOARD_QEMU_VIRT__
+	return 1;
+#endif
 	EFI_STATUS Status;
 	UINTN SelectedIndex = 0;
 	EFI_INPUT_KEY Key;
@@ -445,7 +448,7 @@ extern "C" EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemT
 	
 	const size_t EARLY_PAGE_STACK_SIZE = 1024 * 1024;
 	EFI_PHYSICAL_ADDRESS earlyPhyPageStack = 0;
-	if (!(SystemTable->BootServices->AllocatePages(AllocateAnyPages, EfiLoaderData, EARLY_PAGE_STACK_SIZE / EFI_PAGE_SIZE, (EFI_PHYSICAL_ADDRESS*)&earlyPhyPageStack))) {
+	if ((SystemTable->BootServices->AllocatePages(AllocateAnyPages, EfiLoaderData, EARLY_PAGE_STACK_SIZE / EFI_PAGE_SIZE, (EFI_PHYSICAL_ADDRESS*)&earlyPhyPageStack)) != EFI_SUCCESS) {
 		XEGuiPrint("Early Page Stack: allocation failed.....\n");
 	}
 

--- a/Docs/BuildInstructions(Linux).md
+++ b/Docs/BuildInstructions(Linux).md
@@ -24,6 +24,8 @@ To automate the creation of the FAT32 boot image and launch the OS in QEMU, use 
 3. Run the script:
    `./Scripts/Linux/build_and_run_qemu.sh`
 
+*Note: The GCC build for ARM64 automatically defines `__TARGET_BOARD_QEMU_VIRT__`, which tells the bootloader to bypass the interactive screen resolution menu. This allows QEMU to boot directly into the OS without hanging for user input.*
+
 ### Building `initrd2.img` Manually
 If you do not have a pre-built `initrd2.img` or want to generate a fresh one from the `Resources/resources/` directory, you can pass a flag to force a manual build:
 `./Scripts/Linux/build_and_run_qemu.sh --force-manual-build`

--- a/Docs/BuildInstructions(Linux).md
+++ b/Docs/BuildInstructions(Linux).md
@@ -16,3 +16,15 @@ To build XenevaOS natively on Linux without relying on MSVC, ensure you have the
 2. Run `make clean` and then `make` to compile the C++ source files into the higher-half kernel elf format.
 
 *Note: The GCC port is actively being developed. More subsystems and drivers will be added to the GCC build pipeline over time, moving completely away from Windows-specific Visual Studio configurations.*
+
+## Running in QEMU (Linux/ARM64)
+To automate the creation of the FAT32 boot image and launch the OS in QEMU, use the provided bash script:
+1. Navigate to the root of the XenevaOS repository.
+2. **(Temporary Dev Workaround)** Place a pre-built `initrd2.img` (containing GUI/resources) at the root of the repository. *Note: Using a pre-built ramdisk is a temporary development workaround for the active porting phase to help Linux developers test the user-space GUI easily. In the future, this will be replaced by a dedicated native build step.*
+3. Run the script:
+   `./Scripts/Linux/build_and_run_qemu.sh`
+
+### Building `initrd2.img` Manually
+If you do not have a pre-built `initrd2.img` or want to generate a fresh one from the `Resources/resources/` directory, you can pass a flag to force a manual build:
+`./Scripts/Linux/build_and_run_qemu.sh --force-manual-build`
+*Note: This will require `mkfs.vfat` and `mcopy` (from the `mtools` package) to be installed on your Linux system.*

--- a/Docs/PopulatingConfig.md
+++ b/Docs/PopulatingConfig.md
@@ -3,7 +3,10 @@
 Runtime configuration files are loaded by the kernel to obtain descriptions of the system files required to load. For example, they define which driver files are available in the build image and how they relate to each hardware device. 
 
 ## Aurora Driver Configuration Files
-Aurora Driver configuration files are divided into two types: PCIe-based configuration files and board-based configuration files. Board-based configuration files need to be modified according to the target board; for example, an i.MX8MP-based board needs configuration matching its specific hardware. A PCIe-based configuration file can hold any driver file along with its PCIe subclass/class code or vendor ID/device ID entry.
+Aurora Driver configuration files are divided into two types: PCIe-based configuration files and board-based configuration files. 
+
+- **`board.cnf` (Predefined Hardware):** Used for SoC boards (like Raspberry Pi) where hardware is fixed. It statically links predefined hardware directly to software drivers, making the boot process extremely fast and small in size. Board-based configuration files need to be modified according to the target board (e.g., an i.MX8MP-based board needs configuration matching its specific hardware).
+- **`audrv.cnf` (Dynamic Hardware):** Used for dynamic buses like PCIe. The kernel first discovers available hardware dynamically, then looks up this file to find the matching driver software location. A PCIe-based configuration file can hold any driver file along with its PCIe subclass/class code or vendor ID/device ID entry.
 
 ## The `audrv.cnf` File
 This file must be present in the root folder of the ramdisk image. It holds PCIe-based driver file entries. For example:
@@ -19,4 +22,4 @@ As you can see, there are certain marker points present in the configuration fil
 
 ## The `board.cnf` File
 
-The board configuration file follows a slightly different format than the `audrv.cnf` file. This file also needs to be present in the root folder of the ramdisk. 
+The board configuration file follows a slightly different format than the `audrv.cnf` file. This file also needs to be present in the root folder of the ramdisk. Since it deals with predefined hardware, it maps static hardware identifiers directly to their respective driver files, bypassing dynamic discovery for maximum boot speed and efficiency.

--- a/Kernel/Net/tcp.cpp
+++ b/Kernel/Net/tcp.cpp
@@ -85,7 +85,7 @@ uint16_t CalculateTCPChecksum(TCPCheckHeader* p, TCPHeader* h, void* d, size_t p
 	for (unsigned int i = 0; i < dwords; ++i) {
 		sum += ntohs(s[i]);
 		if (sum > 0xFFFF) 
-			sum = (sum >> 16) + (sum & 0xFFFFF);
+			sum = (sum >> 16) + (sum & 0xFFFF);
 	}
 
 	if (dwords * static_cast<uint64_t>(2) != payloadsz){
@@ -206,7 +206,7 @@ int AuTCPAcknowledge(AuVFSNode* nic, AuSocket* sock, IPv4Header* ippack, size_t 
 	checkhdr.protocol = IPV4_PROTOCOL_TCP;
 	checkhdr.tcpLen = htons(sizeof(TCPHeader));
 
-	tcppack->checksum = htons(CalculateTCPChecksum(&checkhdr, tcp, NULL, 0));
+	tcppack->checksum = htons(CalculateTCPChecksum(&checkhdr, tcppack, NULL, 0));
 	IPV4SendPacket(ipv4, nic);
 	SeTextOut("TCP-ACK Sent !! successfully \r\n");
 	kfree(ipv4);

--- a/KernelAA64/Board/Virt/virt.c
+++ b/KernelAA64/Board/Virt/virt.c
@@ -42,8 +42,8 @@ uint8_t AuVirtIOInputCheck(uint64_t device, int bus,int dev,int func) {
 	uint64_t barLo = AuPCIERead(device, PCI_BAR4, bus, dev, func);
 	uint64_t barHi = AuPCIERead(device, PCI_BAR5, bus, dev, func);
 	uint64_t bar = ((uint64_t)barHi << 32) | (barLo & ~0xFULL);
-	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 2);
-	struct VirtioDeviceConfig* cfg = (struct VirtioDeviceConfig*)(bar + 0x2000);
+	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 16);
+	struct VirtioDeviceConfig* cfg = (struct VirtioDeviceConfig*)(finalAddr + 0x2000);
 	cfg->select = 1;
 	cfg->subsel = 0;
 	isb_flush();
@@ -52,6 +52,7 @@ uint8_t AuVirtIOInputCheck(uint64_t device, int bus,int dev,int func) {
 		return VIRTIO_INPUT_KEYBOARD;
 	else if (strstr(cfg->data.str, "Tablet"))
 		return VIRTIO_INPUT_TABLET;
+	return 0;
 }
 
 /**

--- a/KernelAA64/Drivers/virtiokbd.c
+++ b/KernelAA64/Drivers/virtiokbd.c
@@ -133,8 +133,8 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	uint64_t barLo = AuPCIERead(device, PCI_BAR4, bus, dev, func);
 	uint64_t barHi = AuPCIERead(device, PCI_BAR5, bus, dev, func);
 	uint64_t bar = ((uint64_t)barHi << 32) | (barLo & ~0xFULL);
-	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 2);
-	struct VirtioDeviceConfig* cfg = (struct VirtioDeviceConfig*)(bar + 0x2000);
+	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 16);
+	struct VirtioDeviceConfig* cfg = (struct VirtioDeviceConfig*)(finalAddr + 0x2000);
 	cfg->select = 1;
 	cfg->subsel = 0;
 	isb_flush();
@@ -164,7 +164,7 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	isb_flush();
 	dsb_ish();
 
-	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)bar;
+	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)finalAddr;
 	common->DeviceStatus = 0;
 	
 	isb_flush();

--- a/KernelAA64/Drivers/virtionet.c
+++ b/KernelAA64/Drivers/virtionet.c
@@ -227,7 +227,7 @@ void AuVirtioNetInitialize(uint64_t device) {
 	uint64_t barLo = AuPCIERead(device, PCI_BAR4, bus, dev, func);
 	uint64_t barHi = AuPCIERead(device, PCI_BAR5, bus, dev, func);
 	uint64_t bar = ((uint64_t)barHi << 32) | (barLo & ~0xFULL);
-	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 2);
+	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 16);
 
 
 	uint8_t cap_ptr = AuPCIERead(device, PCI_CAPABILITIES_PTR, bus, dev, func);
@@ -241,7 +241,7 @@ void AuVirtioNetInitialize(uint64_t device) {
 				//break;
 			}
 			if (cap->cfg_type == 2) { //NOTIFY_CFG
-				notifyBase = (volatile uint8_t*)(bar + cap->offset);
+				notifyBase = (volatile uint8_t*)(finalAddr + cap->offset);
 				struct virtio_notifier_cap* notify = (struct virtio_notifier_cap*)cap;
 				notifyOffMultiplier = notify->notifer_mult_base;
 				UARTDebugOut("[virtio-net]: notify base : %x , off : %x\n", notifyBase, cap->offset);
@@ -251,10 +251,10 @@ void AuVirtioNetInitialize(uint64_t device) {
 		cap_ptr = cap->cap_next;
 	}
 
-	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)bar;
+	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)finalAddr;
 	AuVirtioNetReset(common);
 
-	struct VirtioNetCfg* netcfg = (struct VirtioNetCfg*)(bar + devcfg_offset);
+	struct VirtioNetCfg* netcfg = (struct VirtioNetCfg*)(finalAddr + devcfg_offset);
 	
 
 	/* acknowledge */

--- a/KernelAA64/Drivers/virtiotablet.c
+++ b/KernelAA64/Drivers/virtiotablet.c
@@ -146,8 +146,8 @@ void AuVirtioTabletInitialize(uint64_t device) {
 	uint64_t barLo = AuPCIERead(device, PCI_BAR4, bus, dev, func);
 	uint64_t barHi = AuPCIERead(device, PCI_BAR5, bus, dev, func);
 	uint64_t bar = ((uint64_t)barHi << 32) | (barLo & ~0xFULL);
-	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 2);
-	struct VirtioDeviceConfig* cfg = (struct VirtioDeviceConfig*)(bar + 0x2000);
+	uint64_t finalAddr = (uint64_t)AuMapMMIO(bar, 16);
+	struct VirtioDeviceConfig* cfg = (struct VirtioDeviceConfig*)(finalAddr + 0x2000);
 	cfg->select = 1;
 	cfg->subsel = 0;
 	isb_flush();
@@ -191,7 +191,7 @@ void AuVirtioTabletInitialize(uint64_t device) {
 
 	GICRegisterSPIHandler(&AuVirtioTabletHandler, spiID);
 
-	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)bar;
+	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)finalAddr;
 	common->DeviceStatus = 0;
 	isb_flush();
 

--- a/KernelAA64/Fs/Fat/Fat.c
+++ b/KernelAA64/Fs/Fat/Fat.c
@@ -409,7 +409,7 @@ AuVFSNode* FatLocateSubDir(AuVFSNode* fsys, AuVFSNode* kfile, const char* filena
 
 				if (strcmp(name, dos_file_name) == 0) {
 					strcpy(file->filename, filename);
-					file->current = pkDir->first_cluster;
+					file->current = (pkDir->first_cluster_hi_bytes << 16) | pkDir->first_cluster;
 					file->size = pkDir->file_size;
 					file->eof = 0;
 					file->pos = 0;
@@ -465,45 +465,49 @@ AuVFSNode* FatLocateDir(AuVFSNode* fsys, const char* dir) {
 	buf = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
 	memset(buf, 0, PAGE_SIZE);
 
-	for (unsigned int sector = 0; sector < fs->__SectorPerCluster; sector++) {
+	uint32_t current_cluster = fs->__RootDirFirstCluster;
 
-		memset(buf, 0, PAGE_SIZE);
-		//ata_read_28 (root_sector + sector,1, buf);
-		AuVDiskRead(vdisk, FatClusterToSector32(fs, fs->__RootDirFirstCluster) + sector, 1, buf);
+	while (current_cluster < 0x0FFFFFF8 && current_cluster != 0) {
+		for (unsigned int sector = 0; sector < fs->__SectorPerCluster; sector++) {
 
-		dirent = (FatDir*)buf;
+			memset(buf, 0, PAGE_SIZE);
+			AuVDiskRead(vdisk, FatClusterToSector32(fs, current_cluster) + sector, 1, buf);
 
-		for (int i = 0; i < 16; i++) {
-		
-			if (strncmp(dos_file_name, dirent->filename,11) == 0) {
-				strcpy(file->filename, dir);
-				file->current = dirent->first_cluster;
-				file->size = dirent->file_size;
-				file->eof = 0;
-				file->status = FS_STATUS_FOUND;
-				file->close = 0;
-				file->first_block = file->current;
-				file->pos = 0;
-				file->device = fsys;
-				file->parent_block = fs->__RootDirFirstCluster;
-				file->open = 0;
-				file->write = 0;
-				file->create_file = 0;
+			dirent = (FatDir*)buf;
 
-				/* FAT32 doesn't has UID/GID value stored in file, so
-				 * using global misc world gid 
-				 */
-				file->gid = AuCredGetGroupID(AURORA_GID_MISC_WORLD);
-				if (dirent->attrib == 0x10)
-					file->flags |= FS_FLAG_DIRECTORY;
-				else
-					file->flags |= FS_FLAG_GENERAL;
-				aa64_data_cache_clean_range(file, sizeof(AuVFSNode));
-				AuPmmngrFree((void*)V2P((size_t)buf));
-				return file;
+			for (int i = 0; i < 16; i++) {
+			
+				if (strncmp(dos_file_name, dirent->filename,11) == 0) {
+					strcpy(file->filename, dir);
+					file->current = (dirent->first_cluster_hi_bytes << 16) | dirent->first_cluster;
+					file->size = dirent->file_size;
+					file->eof = 0;
+					file->status = FS_STATUS_FOUND;
+					file->close = 0;
+					file->first_block = file->current;
+					file->pos = 0;
+					file->device = fsys;
+					file->parent_block = current_cluster;
+					file->open = 0;
+					file->write = 0;
+					file->create_file = 0;
+
+					/* FAT32 doesn't has UID/GID value stored in file, so
+					 * using global misc world gid 
+					 */
+					file->gid = AuCredGetGroupID(AURORA_GID_MISC_WORLD);
+					if (dirent->attrib == 0x10)
+						file->flags |= FS_FLAG_DIRECTORY;
+					else
+						file->flags |= FS_FLAG_GENERAL;
+					aa64_data_cache_clean_range(file, sizeof(AuVFSNode));
+					AuPmmngrFree((void*)V2P((size_t)buf));
+					return file;
+				}
+				dirent++;
 			}
-			dirent++;
 		}
+		current_cluster = FatReadFAT(fsys, current_cluster);
 	}
 
 	AuPmmngrFree((void*)V2P((size_t)buf));

--- a/KernelAA64/Fs/initrd.c
+++ b/KernelAA64/Fs/initrd.c
@@ -58,7 +58,8 @@ uint64_t ramdisk_end;
  */
 void AuRamdiskRead(uint64_t lba, size_t count, uint8_t* buffer) {
 	uint64_t offset = lba * RAMDISK_SECTOR_SIZE;
-	if (ramdisk_start + offset + (RAMDISK_SECTOR_SIZE * count) > ramdisk_end)
+	if (offset >= (ramdisk_end - ramdisk_start) || 
+	    (RAMDISK_SECTOR_SIZE * count) > (ramdisk_end - ramdisk_start - offset))
 		return;
 
 	const uint8_t* src = (const uint8_t*)(ramdisk_start + offset);
@@ -74,7 +75,8 @@ void AuRamdiskRead(uint64_t lba, size_t count, uint8_t* buffer) {
  */
 void AuRamdiskWrite(uint64_t lba, size_t count, uint8_t* buffer) {
 	uint64_t offset = lba * RAMDISK_SECTOR_SIZE;
-	if (ramdisk_start + offset + (RAMDISK_SECTOR_SIZE * count) > ramdisk_end)
+	if (offset >= (ramdisk_end - ramdisk_start) || 
+	    (RAMDISK_SECTOR_SIZE * count) > (ramdisk_end - ramdisk_start - offset))
 		return;
 	uint8_t* src = (uint8_t*)(ramdisk_start + offset);
 	for (int i = 0; i < RAMDISK_SECTOR_SIZE * count; i++)

--- a/KernelAA64/Fs/vdisk.c
+++ b/KernelAA64/Fs/vdisk.c
@@ -244,7 +244,7 @@ void AuVDiskRegister(AuVDisk* disk) {
 		char* mpt = AuVFSReserveMountPointLetter();
 		
 		/** make letter /a reserved for root '/' **/
-		if (strcmp(mpt, "/a") == 0)
+		if (strcmp(mpt, "a") == 0)
 			FatInitialise(disk, "/");
 		else
 			FatInitialise(disk, mpt);

--- a/KernelAA64/Mm/kmalloc.c
+++ b/KernelAA64/Mm/kmalloc.c
@@ -457,7 +457,9 @@ void* au_request_page(int pages) {
 	
 #ifdef _USE_DLMALLOC
 	//UARTDebugOut("[au_request_page]: num_pages : %d, ptr : %x \r\n", pages, page_);
+	/* dlmalloc passes SIZE IN BYTES, convert to page count */
 	pages = (pages + 4095) / 4096;
+	if (pages < 1) pages = 1;
 #endif
 	for (size_t i = 0; i < pages; i++) {
 		void* p = AuPmmngrAlloc();

--- a/KernelAA64/Mm/pmmngr.c
+++ b/KernelAA64/Mm/pmmngr.c
@@ -166,12 +166,19 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 	void* BitmapArea = 0;
 	bool print = 0;
 	
+	uint64_t HighestAddress = 0;
+	
 	if (info->boot_type != BOOT_LITTLEBOOT_ARM64) {
 		MemMapEntries = info->mem_map_size / info->descriptor_size;
 		/* Scan a suitable area for the bitmap */
 		for (size_t i = 0; i < MemMapEntries; i++) {
 			EFI_MEMORY_DESCRIPTOR* EfiMem = (EFI_MEMORY_DESCRIPTOR*)((uint64_t)info->map + i * info->descriptor_size);
 		
+			uint64_t end_addr = EfiMem->phys_start + (EfiMem->num_pages * 4096);
+			if (end_addr > HighestAddress) {
+				HighestAddress = end_addr;
+			}
+
 			if (EfiMem->type == 7) {
 				_TotalRam += EfiMem->num_pages;
 				if (((EfiMem->num_pages * 4096) > 0x1F0000) && BitmapArea == 0) {
@@ -210,6 +217,10 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 		for (size_t i = 0; i < lb->usable_region_count; i++) {
 			uint64_t base = memRegn[i].base;
 			uint64_t numPages = memRegn[i].pageCount;
+			uint64_t end_addr = base + (numPages * 4096);
+			if (end_addr > HighestAddress) {
+				HighestAddress = end_addr;
+			}
 			if (((numPages * 4096) > 0x1F0000) && BitmapArea == 0) {
 				BitmapArea = (void*)base;
 			}
@@ -224,14 +235,14 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 
 	_FreeMemory = _TotalRam;
 	AuTextOut("Total RAM : %x \r\n", (_TotalRam * 0x1000));
+	AuTextOut("Highest Address : %x \r\n", HighestAddress);
 
-
-
-	uint64_t BitmapSize = (_TotalRam / 8) + 1; // (_TotalRam * 4096) / 4096 / 8 + 1;
+	uint64_t TotalPagesCount = HighestAddress / 4096;
+	uint64_t BitmapSize = (TotalPagesCount / 8) + 1; // (_TotalRam * 4096) / 4096 / 8 + 1;
 	uint64_t page_desc_addr = (uint64_t)BitmapArea + BitmapSize;
 	page_desc_addr = ALIGN_UP(page_desc_addr, 64);
 	page_desc = (AuPageDesc*)page_desc_addr;
-	total_page_desc_count = _TotalRam;
+	total_page_desc_count = TotalPagesCount;
 	size_t page_desc_len = total_page_desc_count * sizeof(AuPageDesc);
 	UsablePhysicalMemory = (uint64_t)page_desc_addr + page_desc_len;
 	UsablePhysicalMemory = (UsablePhysicalMemory + (PAGE_SIZE - 1)) & ~(uint64_t)(PAGE_SIZE - 1);
@@ -250,8 +261,7 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 		for (size_t i = 0; i < MemMapEntries; i++) {
 			EFI_MEMORY_DESCRIPTOR* EfiMem = (EFI_MEMORY_DESCRIPTOR*)((uint64_t)info->map + i * info->descriptor_size);
 			//_TotalRam += EfiMem->num_pages;
-			if (EfiMem->type != 7 || EfiMem->type != 1 || EfiMem->type != 2 ||
-				EfiMem->type != 3 || EfiMem->type != 4) {
+			if (EfiMem->type != 7) {
 				uint64_t PhysStart = EfiMem->phys_start;
 				for (size_t j = 0; j < EfiMem->num_pages; j++) {
 					AuPmmngrLockPage(PhysStart + j * 4096);
@@ -269,10 +279,14 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 	uint64_t* AllocStack = (uint64_t*)info->allocated_stack;
 	while (AllocCount) {
 		uint64_t Address = *AllocStack--;
-		uint64_t index = (Address - UsablePhysicalMemory);
-		AuPmmngrLockPage(index);
+		AuPmmngrLockPage(Address);
 		AllocCount--;
 	}
+
+	for (uint64_t i = 0; i < (UsablePhysicalMemory >> PAGE_SHIFT); i++) {
+		AuPmmngrLockPage(i * PAGE_SIZE);
+	}
+	_RamBitmapIndex = UsablePhysicalMemory >> PAGE_SHIFT;
 
 	/* need more reservation of memory allocated by initrd and others*/
 	if (info->boot_type == BOOT_LITTLEBOOT_ARM64) {
@@ -332,16 +346,15 @@ void* AuPmmngrAlloc() {
 	for (; _RamBitmapIndex < _BitmapSize * 8; _RamBitmapIndex++) {
 		//AuTextOut("  RamBitmap[%d] -> %d   ",_RamBitmapIndex, RamBitmap[_RamBitmapIndex]);
 		if (AuPmmngrBitmapCheck(_RamBitmapIndex)) continue;
-		AuPmmngrLockPage(_RamBitmapIndex * 4096);
+		AuPmmngrLockPage(_RamBitmapIndex * PAGE_SIZE);
 		_UsedMemory++;
 		uint64_t index = _RamBitmapIndex;
 		//UARTDebugOut("AuPmmngrAlloc: RamBitmapIndex : %d %x \n", _RamBitmapIndex, (UsablePhysicalMemory + (index * 4096)));
-		page_desc[(UsablePhysicalMemory + (index * PAGE_SIZE)) >> PAGE_SHIFT].refcount = 1;
-		page_desc[(UsablePhysicalMemory + (index * PAGE_SIZE)) >> PAGE_SHIFT].phys_addr = 
-			(UsablePhysicalMemory + (index * PAGE_SIZE));
-		page_desc[(UsablePhysicalMemory + (index * PAGE_SIZE)) >> PAGE_SHIFT].diskblock = -1;
+		page_desc[index].refcount = 1;
+		page_desc[index].phys_addr = (index * PAGE_SIZE);
+		page_desc[index].diskblock = -1;
 	//	UARTDebugOut("Page desc : %x \r\n", &page_desc[(UsablePhysicalMemory + (index * PAGE_SIZE)) >> PAGE_SHIFT]);
-		return (void*)(UsablePhysicalMemory + (index * 4096));
+		return (void*)(index * PAGE_SIZE);
 	}
 	AuTextOut("Kernel Panic!!! No more physical memory \n");
 	for (;;);
@@ -373,8 +386,7 @@ void AuPmmngrFree(void* Address) {
 		page_desc[ShiftAddr].refcount -= 1;
 		return;
 	}
-	uint64_t addr = ((uint64_t)Address - UsablePhysicalMemory);
-	uint64_t Index = (uint64_t)addr / 4096;
+	uint64_t Index = ShiftAddr;
 	if (AuPmmngrBitmapCheck(Index) == false) return;
 	if (AuPmmngrBitmapSet(Index, false)) {
 		//UARTDebugOut("Was not free actual address : %x\n", Address);

--- a/KernelAA64/audrv.c
+++ b/KernelAA64/audrv.c
@@ -296,14 +296,12 @@ void AuDriverLoad(char* filename, AuDriver* driver) {
 		return;
 	}
 	
-	int sbIndex = 0;
+	size_t file_offset = 0;
 	while (file->eof != 1) {
-		uint64_t block = ((uint64_t)scratchBuffer + (sbIndex * 0x1000));
-		memset(block, 0, 4096);
-		AuVFSNodeReadBlock(fsys, file, block);
-		sbIndex++;
-		//AuMapPage((uint64_t)block, (driver_load_base + next_base_offset * 4096), 0);
-		//next_base_offset++;
+		uint64_t block = ((uint64_t)scratchBuffer + file_offset);
+		size_t bytes_read = AuVFSNodeReadBlock(fsys, file, block);
+		if (bytes_read == 0) break;
+		file_offset += bytes_read;
 	}
 
 	IMAGE_DOS_HEADER* dos_ = (IMAGE_DOS_HEADER*)scratchBuffer;
@@ -607,10 +605,11 @@ AuDriver* AuDrvManagerCheckFault(uint64_t fault_addr) {
 	for (int i = 0; i < 246; i++) {
 		AuDriver* drv = drivers[i];
 		if (drv) {
-			if (fault_addr > drv->new_load_base || fault_addr <= drv->new_load_base + drv->image_sz)
+			if (drv->new_load_base != 0 && fault_addr > drv->new_load_base && fault_addr <= drv->new_load_base + drv->image_sz)
 				return drv;
 		}
 	}
+	return NULL;
 }
 
 /**

--- a/KernelAA64/audrv.c
+++ b/KernelAA64/audrv.c
@@ -321,15 +321,22 @@ void AuDriverLoad(char* filename, AuDriver* driver) {
 		size_t load_addr = (size_t)virtual_base + sectionHeader[i].VirtualAddress;
 		void* sect_addr = (void*)load_addr;
 		size_t sectsz = sectionHeader[i].VirtualSize;
-		int req_pages = sectsz / 4096 +
-			((sectsz % 4096) ? 1 : 0);
+		if (sectionHeader[i].SizeOfRawData > sectsz)
+			sectsz = sectionHeader[i].SizeOfRawData;
+			
+		size_t aligned_addr = load_addr & ~0xFFFULL;
+		int req_pages = (sectsz + (load_addr & 0xFFF)) / 4096 + 
+			(((sectsz + (load_addr & 0xFFF)) % 4096) ? 1 : 0);
 		uint64_t* block = 0;
 		for (int j = 0; j < req_pages; j++) {
-			uint64_t alloc = (load_addr + j * 0x1000);
-			AuMapPage((uint64_t)AuPmmngrAlloc(), alloc, PTE_NORMAL_MEM);
+			uint64_t alloc = (aligned_addr + j * 0x1000);
+			if (!AuGetPhysicalAddress(alloc)) {
+				AuMapPage((uint64_t)AuPmmngrAlloc(), alloc, PTE_NORMAL_MEM);
+				memset((void*)alloc, 0, 4096);
+				next_base_offset++;
+			}
 			if (!block)
 				block = (uint64_t*)alloc;
-			next_base_offset++;
 		}
 
 		memcpy(sect_addr, RAW_OFFSET(void*,scratchBuffer, sectionHeader[i].PointerToRawData), sectionHeader[i].SizeOfRawData);

--- a/KernelAA64/kernel_exports.c
+++ b/KernelAA64/kernel_exports.c
@@ -1,0 +1,60 @@
+#ifdef __GNUC__
+
+#include <stdint.h>
+#include <stddef.h>
+
+struct kernel_export {
+    char* name;
+    void* addr;
+};
+
+/* Drivers declarations */
+extern void AuPCIEAllocMSI(void);
+extern void AuPCIEScanClass(void);
+extern void AuPCIEWrite(void);
+extern void AuPCIERead(void);
+extern void dsb_ish(void);
+extern void isb_flush(void);
+extern void GICEnableSPIIRQ(void);
+extern void AuGICAllocateSPI(void);
+extern void GICRegisterSPIHandler(void);
+extern void UARTDebugOut(void);
+extern void AuPmmngrAlloc(void);
+extern void AuPmmngrAllocBlocks(void);
+extern void AuTextOut(void);
+extern void AuAddNetAdapter(void);
+extern void AuMapMMIO(void);
+extern void strcpy(void);
+extern void memset(void);
+extern void memcpy(void);
+extern void kmalloc(void);
+extern void AuEthernetHandle(void);
+extern void P2V(void);
+
+struct kernel_export k_exports[] = {
+    {"AuPCIEAllocMSI", (void*)AuPCIEAllocMSI},
+    {"AuPCIEScanClass", (void*)AuPCIEScanClass},
+    {"AuPCIEWrite", (void*)AuPCIEWrite},
+    {"AuPCIERead", (void*)AuPCIERead},
+    {"dsb_ish", (void*)dsb_ish},
+    {"isb_flush", (void*)isb_flush},
+    {"GICEnableSPIIRQ", (void*)GICEnableSPIIRQ},
+    {"AuGICAllocateSPI", (void*)AuGICAllocateSPI},
+    {"GICRegisterSPIHandler", (void*)GICRegisterSPIHandler},
+    {"UARTDebugOut", (void*)UARTDebugOut},
+    {"AuPmmngrAlloc", (void*)AuPmmngrAlloc},
+    {"AuPmmngrAllocBlocks", (void*)AuPmmngrAllocBlocks},
+    {"P2V", (void*)P2V},
+    {"AuTextOut", (void*)AuTextOut},
+    {"AuAddNetAdapter", (void*)AuAddNetAdapter},
+    {"AuMapMMIO", (void*)AuMapMMIO},
+    {"strcpy", (void*)strcpy},
+    {"memset", (void*)memset},
+    {"memcpy", (void*)memcpy},
+    {"kmalloc", (void*)kmalloc},
+    {"AuEthernetHandle", (void*)AuEthernetHandle},
+};
+
+int k_exports_count = sizeof(k_exports) / sizeof(struct kernel_export);
+
+#endif

--- a/KernelAA64/loader.c
+++ b/KernelAA64/loader.c
@@ -203,6 +203,10 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 	else {
 		UARTDebugOut("[loader.c]: file : %s was not in cache adding it \r\n", filename);
 		file = AuVFSOpen(filename);
+		if (!file) {
+			UARTDebugOut("[loader.c]: Failed to open file %s\r\n", filename);
+			return -1;
+		}
 		fb = (AuMMFileBack*)kmalloc(sizeof(AuMMFileBack));
 		memset(fb, 0, sizeof(AuMMFileBack));
 		file->flags |= FS_FLAG_CACHED;
@@ -222,35 +226,39 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 	if (file->eof == 1 && fb->readComplete == 1)
 		file->eof = 0;
 
-	int sbIndex = 0;
-	while (file->eof != 1) {
-		uint64_t physcache = NULL;
-		if (fb->readComplete == false) {
-			physcache = (uint64_t)AuPmmngrAlloc();
+	if (fb->readComplete == false) {
+		size_t file_offset = 0;
+		while (file->eof != 1) {
+			uint64_t block = ((uint64_t)_ldr_scratchBuffer + file_offset);
+			size_t bytes_read = AuVFSNodeReadBlock(fsys, file, block);
+			if (bytes_read == 0) break;
+			file_offset += bytes_read;
+		}
+
+		size_t total_pages = file_offset / PAGE_SIZE + ((file_offset % PAGE_SIZE) ? 1 : 0);
+		for (size_t i = 0; i < total_pages; i++) {
+			uint64_t physcache = (uint64_t)AuPmmngrAlloc();
 			AuMMPageCache* cache = AuMmngrPageCacheCreate();
 			cache->physicalPage = physcache;
-			cache->diskBlock = fsys->get_disk_block(fsys, file, file->current);
-			cache->pageIndex = sbIndex;
+			cache->diskBlock = 0;
+			cache->pageIndex = i;
 			AuMmngrFileBackAddPageCache(fb, cache);
-			uint64_t block = ((uint64_t)_ldr_scratchBuffer + (sbIndex * 0x1000));
-			memset(block, 0, 4096);
-			AuVFSNodeReadBlock(fsys, file, block);
-			if (physcache) {
-				memcpy(P2V(physcache), block, PAGE_SIZE);
-			}
+
+			memset((void*)P2V(physcache), 0, PAGE_SIZE);
+			size_t copy_sz = PAGE_SIZE;
+			if (i == total_pages - 1 && (file_offset % PAGE_SIZE) != 0)
+				copy_sz = file_offset % PAGE_SIZE;
+			memcpy(P2V(physcache), (void*)((uint64_t)_ldr_scratchBuffer + i * PAGE_SIZE), copy_sz);
 		}
-		else {
-			if (pcache == NULL) {
-				break;
-			}
-			uint64_t block = ((uint64_t)_ldr_scratchBuffer + (sbIndex * 0x1000));
-			memset(block, 0, 4096);
-			memcpy(block, P2V(pcache->physicalPage), PAGE_SIZE);
-			if (physcache)
-				memcpy(P2V(physcache), block, PAGE_SIZE);
+		fb->readComplete = true;
+	} else {
+		AuMMPageCache* pcache = fb->pageCache;
+		size_t file_offset = 0;
+		while (pcache != NULL) {
+			memcpy((void*)((uint64_t)_ldr_scratchBuffer + file_offset), P2V(pcache->physicalPage), PAGE_SIZE);
+			file_offset += PAGE_SIZE;
 			pcache = pcache->next;
 		}
-		sbIndex++;
 	}
 	
 	fb->readComplete = 1;

--- a/KernelAA64/pcie.c
+++ b/KernelAA64/pcie.c
@@ -42,7 +42,7 @@
 #include <Hal/AA64/aa64lowlevel.h>
 #include <Drivers/uart.h>
 
-#define QEMU_VIRT_ECAM_BASE 0x4010000000ULL
+#define QEMU_VIRT_ECAM_BASE 0x3f000000
 
 static uint64_t _ecamAddress;
 static bool _pcieInitialized;

--- a/KernelAA64/pcie.c
+++ b/KernelAA64/pcie.c
@@ -73,7 +73,7 @@ static int _pcie_check_and_map_dtb() {
 static bool _pcie_use_hard_code_ecam() {
 	AuTextOut("[aurora]: pcie getting hard code ecam address \r\n");
 #ifdef __TARGET_BOARD_QEMU_VIRT__
-	_ecamAddress = QEMU_VIRT_ECAM_BASE; // AuMapMMIO(QEMU_VIRT_ECAM_BASE, 0x10000000 / 0x1000);
+	_ecamAddress = (uint64_t)AuMapMMIO(QEMU_VIRT_ECAM_BASE, 0x10000000 / 0x1000);
 #elif __TARGET_BOARD_RPI3__
 	_ecamAddress = 0;
 #elif __TARGET_BOARD_IMX8MP_VERDIN_DAHLIA__

--- a/KernelAA64/pe.c
+++ b/KernelAA64/pe.c
@@ -36,6 +36,18 @@
 #include <stdint.h>
 #include <Drivers/uart.h>
 
+#define IMAGE_DOS_SIGNATURE 0x5A4D
+#define IMAGE_NT_SIGNATURE  0x00004550
+
+#ifdef __GNUC__
+struct kernel_export {
+    char* name;
+    void* addr;
+};
+extern struct kernel_export k_exports[];
+extern int k_exports_count;
+#endif
+
 /**
  * @brief AuGetProcAddress -- get procedure address in a dll image
  * @param image -- dll image
@@ -43,13 +55,32 @@
  * @return return the procedure address in memory
  */
 void* AuGetProcAddress(void* image, const char* procname) {
+#ifdef __GNUC__
+	if (image == (void*)0xFFFFC00000000000) {
+		for (int i = 0; i < k_exports_count; i++) {
+			if (strcmp(k_exports[i].name, procname) == 0) {
+				return k_exports[i].addr;
+			}
+		}
+		return NULL;
+	}
+#endif
+
 	IMAGE_DOS_HEADER* dos_header = (IMAGE_DOS_HEADER*)image;
+	if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) {
+		return NULL;
+	}
 	PIMAGE_NT_HEADERS ntHeaders = RAW_OFFSET(IMAGE_NT_HEADERS*,dos_header, dos_header->e_lfanew);
-	if (IMAGE_DATA_DIRECTORY_EXPORT + 1 > ntHeaders->OptionalHeader.NumberOfRvaAndSizes)
+	if (ntHeaders->Signature != IMAGE_NT_SIGNATURE) {
 		return NULL;
+	}
+	if (IMAGE_DATA_DIRECTORY_EXPORT + 1 > ntHeaders->OptionalHeader.NumberOfRvaAndSizes) {
+		return NULL;
+	}
 	IMAGE_DATA_DIRECTORY datadir = ntHeaders->OptionalHeader.DataDirectory[IMAGE_DATA_DIRECTORY_EXPORT];
-	if (datadir.VirtualAddress == 0 || datadir.Size == 0)
+	if (datadir.VirtualAddress == 0 || datadir.Size == 0) {
 		return NULL;
+	}
 	PIMAGE_EXPORT_DIRECTORY exportdir = RAW_OFFSET(PIMAGE_EXPORT_DIRECTORY,image, datadir.VirtualAddress);
 	uint32_t* FuntionNameAddressArray = RAW_OFFSET(uint32_t*,image, exportdir->AddressOfNames);
 	uint16_t* FunctionOrdinalAddressArray = RAW_OFFSET(uint16_t*,image, exportdir->AddressOfNameOrdinal);
@@ -99,7 +130,9 @@ void AuPEPrintExports(void* image) {
 void AuKernelLinkDLL(void* image) {
 	uint8_t* imageAligned = (uint8_t*)image;
 	PIMAGE_DOS_HEADER dos_header = (PIMAGE_DOS_HEADER)imageAligned;
+	if (dos_header->e_magic != IMAGE_DOS_SIGNATURE) return;
 	PIMAGE_NT_HEADERS nt_headers = RAW_OFFSET(PIMAGE_NT_HEADERS,dos_header, dos_header->e_lfanew);
+	if (nt_headers->Signature != IMAGE_NT_SIGNATURE) return;
 	if (IMAGE_DATA_DIRECTORY_IMPORT + 1 > nt_headers->OptionalHeader.NumberOfRvaAndSizes)
 		return;
 	IMAGE_DATA_DIRECTORY datadir = nt_headers->OptionalHeader.DataDirectory[IMAGE_DATA_DIRECTORY_IMPORT];

--- a/Process/XEShell/main.cpp
+++ b/Process/XEShell/main.cpp
@@ -408,10 +408,12 @@ void XEShellProcessLine() {
 			_spawnable_process = false;
 		}
 
-		if (strstr(cmdBuf, "cd")) {
+		if (strncmp(cmdBuf, "cd ", 3) == 0 || strcmp(cmdBuf, "cd") == 0) {
 			char* path = cmdBuf + 2;
-			while (strstr(path, " "))
-				path++;
+			if (*path == ' ') {
+				while (*path == ' ')
+					path++;
+			}
 			XEShellCD(path);
 			printf("\n");
 			_spawnable_process = false;
@@ -422,8 +424,12 @@ void XEShellProcessLine() {
 			_spawnable_process = false;
 		}
 
-		if (strstr(cmdBuf, "echo")) {
+		if (strncmp(cmdBuf, "echo ", 5) == 0 || strcmp(cmdBuf, "echo") == 0) {
 			char* msg = cmdBuf + 4;
+			if (*msg == ' ') {
+				while (*msg == ' ')
+					msg++;
+			}
 			XEShellEcho(msg);
 			_spawnable_process = false;
 		}

--- a/Scripts/Linux/build_and_run_qemu.sh
+++ b/Scripts/Linux/build_and_run_qemu.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -e
 
-echo "[+] Creating 128MB FAT32 image..."
-dd if=/dev/zero of=fat.img bs=1M count=128
+# Check for manual build flag
+FORCE_MANUAL_BUILD=0
+if [ "$1" == "--force-manual-build" ]; then
+    FORCE_MANUAL_BUILD=1
+fi
+
+
+echo "[+] Creating 512MB FAT32 image..."
+dd if=/dev/zero of=fat.img bs=1M count=512
 mkfs.vfat fat.img
 
 echo "[+] Copying EFI Bootloader and Kernel via mtools..."
@@ -10,17 +17,32 @@ mmd -i fat.img ::/EFI
 mmd -i fat.img ::/EFI/BOOT
 mmd -i fat.img ::/EFI/XENEVA
 
-echo "[+] Creating 64MB FAT32 initrd2.img and packing resources..."
-dd if=/dev/zero of=initrd2.img bs=1M count=64
-mkfs.vfat -F 32 initrd2.img
-mcopy -i initrd2.img Resources/resources/* ::/
+# [Note: (Temporary Dev Workaround)
+# During the active porting phase, you can place a pre-built initrd2.img
+# (with GUI/resources) at the root of the repository to skip manual building.
+# Example Directory Structure:
+#   XenevaOS/
+#   ├── KernelAA64/
+#   ├── BootAA64/
+#   ├── Scripts/
+#   └── initrd2.img   <-- Place it exactly here
+# ]
+if [ "$FORCE_MANUAL_BUILD" -eq 1 ] || [ ! -f "initrd2.img" ]; then
+    echo "[+] Creating 64MB FAT32 initrd2.img and packing resources..."
+    dd if=/dev/zero of=initrd2.img bs=1M count=64
+    mkfs.vfat -F 32 initrd2.img
+    mcopy -i initrd2.img Resources/resources/* ::/
+else
+    echo "[+] Found pre-built initrd2.img, skipping manual creation."
+    echo "    (Use --force-manual-build flag to override)"
+fi
 
 mcopy -i fat.img BootAA64/Build/EFI/BOOT/BOOTAA64.efi ::/EFI/BOOT/BOOTAA64.EFI
 mcopy -i fat.img KernelAA64/KernelAA64.exe ::/EFI/XENEVA/xnkrnl.exe
 mcopy -i fat.img initrd2.img ::/initrd2.img
 
 echo "[+] Image ready! Booting QEMU..."
-qemu-system-aarch64 -machine virt,gic-version=2 \
+qemu-system-aarch64 -machine virt,gic-version=2,highmem=off \
     -cpu cortex-a57 -m 1024M \
     -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
     -drive file=fat.img,format=raw,if=virtio \


### PR DESCRIPTION
## Overview
This PR introduces comprehensive Linux GCC cross-compilation support for XenevaOS and addresses multiple critical architectural bugs that were previously hidden in the MSVC builds but caused synchronous exceptions (Data Aborts) on the ARM64 QEMU Virt board. 

The codebase is now significantly more compatible across both Windows/MSVC and Linux/GCC environments, with the primary bootloader and kernel workflows validated on both toolchains.

## Key Changes & Fixes

### 1. Cross-Platform Compatibility (GCC vs MSVC)
- **Header Paths:** Fixed thousands of Windows-specific backslash `\` path separators to POSIX-compliant forward slashes `/` across all `#include` directives (e.g., `<sys\_keproc.h>` to `<sys/_keproc.h>`).
- **Build System:** Added new Linux-compatible Makefiles, GCC compilation scripts, and updated documentation (`Docs/BuildInstructions(Linux).md`).
- **QEMU Runner:** Created `Scripts/Linux/build_and_run_qemu.sh` to automate disk image creation, EFI bootloader packing, and QEMU ARM64 execution natively on Linux.

### 2. ARM64 Kernel Stability & Bug Fixes
- **FAT32 32-bit Cluster Truncation:** Fixed a critical bug in `Fat.c` where large RAM disks (>64MB) caused infinite cluster loops (`0 -> 0x0FFFFFF0`). The loader now correctly reconstructs the 32-bit starting cluster using `first_cluster_hi_bytes`.
- **VFS Memory Fragmentation:** Refactored `AuLoadExecToProcess` and driver loading in `loader.c`/`audrv.c` to use dynamic `bytes_read` instead of assuming strict 4096-byte chunk reads. This fixes memory fragmentation issues caused by variable FAT cluster sizes.
- **PCIe ECAM Mapping:** Resolved an initialization Data Abort by adding proper `AuMapMMIO` page mapping for the QEMU hardcoded ECAM address in `pcie.c`.
- **Ramdisk Security:** Hardened out-of-bounds checking in `initrd.c` to prevent severe arithmetic integer overflows on corrupted filesystems.

### 3. CI/CD Integration
- **GitHub Actions:** Added an initial CI workflow (`.github/workflows/build-check.yml`) to automatically build and validate both Windows MSVC builds and Linux GCC cross-compilation on every push and pull request.

## Testing Performed
- Successfully compiled entire OS using `aarch64-linux-gnu-gcc` on Linux.
- Booted QEMU Virt board with UEFI firmware on ARM64.
- `init.exe` user-space transition succeeded without `EC 25` Synchronous Exceptions.
- Verified MSVC/Windows backward compatibility on existing tools.
