### PR TITLE
compat: improve GCC compatibility for variadic arguments and integer types

### DIFF
--- a/BaseHdr/Hal/AA64/sched.h
+++ b/BaseHdr/Hal/AA64/sched.h
@@ -59,7 +59,8 @@ typedef struct _uentry_ {
 	uint64_t cs;
 	uint64_t ss;
 	int num_args;
-	uint64_t argvaddr;
+	uint64_t argvaddr;    /* user-space VA of argv[] page (for crt0 via stack) */
+	uint64_t argvkernel;  /* kernel-space VA of argv[] page (for EL1 writes) */
 	char** argvs;
 	uint64_t stackBase;
 }AuUserEntry;

--- a/BaseHdr/stdarg.h
+++ b/BaseHdr/stdarg.h
@@ -38,8 +38,12 @@ extern "C"
 #endif
 
 
+#ifdef __GNUC__
+	typedef __builtin_va_list va_list;
+#else
 	/* va list parameter list */
 	typedef unsigned char* va_list;
+#endif
 
 
 	/* width of stack == width of int */
@@ -51,7 +55,7 @@ extern "C"
 	((sizeof(TYPE)+sizeof(STACKITEM)-1)	\
 	& ~(sizeof(STACKITEM)-1))
 
-#ifdef ARCH_X64
+#if defined(ARCH_X64) || defined(__x86_64__)
 	/* &(LASTARG) points to the LEFTMOST argument of the function call
 	(before the ...) */
 #define	va_start(AP, LASTARG)	\
@@ -62,7 +66,12 @@ extern "C"
 
 #define va_arg(AP, TYPE)	\
 	(AP += VA_SIZE(TYPE), *((TYPE *)(AP - VA_SIZE(TYPE))))
-#elif ARCH_ARM64
+#elif defined(ARCH_ARM64) || defined(__aarch64__)
+#ifdef __GNUC__
+#define va_start(ap, last) __builtin_va_start(ap, last)
+#define va_arg(ap, type) __builtin_va_arg(ap, type)
+#define va_end(ap) __builtin_va_end(ap)
+#else
 #define va_start(ap,last) \
      ((ap) = (va_list)(&(last)) + 8)
 
@@ -71,6 +80,7 @@ extern "C"
 
 #define va_end(ap) \
      ((ap) = (va_list)0)
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/BaseHdr/stdint.h
+++ b/BaseHdr/stdint.h
@@ -88,21 +88,22 @@ typedef unsigned  int  uint_fast32_t;
 typedef long long  int_fast64_t;
 typedef unsigned long long   uint_fast64_t;
 
-/* 7.18.1.4  Integer types capable of holding object pointers */
-typedef int intptr_t;
-
-#if defined(ARCH_ARM64) || defined(ARCH_X64)
-typedef __int64 uintptr_t;
+#if defined(ARCH_ARM64) || defined(__aarch64__) || defined(ARCH_X64) || defined(__x86_64__)
+typedef long long intptr_t;
+typedef unsigned long long uintptr_t;
 #else
+typedef int intptr_t;
 typedef unsigned int uintptr_t;
 #endif
 
 /* 7.18.1.5  Greatest-width integer types */
 typedef long long  intmax_t;
 typedef unsigned long long   uintmax_t;
-
+#ifdef __SIZE_TYPE__
+typedef __SIZE_TYPE__ size_t;
+#else
 typedef uint64_t size_t;
-
+#endif
 /* 7.18.2  Limits of specified-width integer types */
 #if defined ( __cplusplus) || defined (__STDC_LIMIT_MACROS)
 
@@ -171,9 +172,13 @@ object pointers */
 
 #define SIG_ATOMIC_MIN INT32_MIN
 #define SIG_ATOMIC_MAX INT32_MAX
-
-#define SIZE_MAX  0xFFFFF      //UINT32_MAX
-
+#ifndef SIZE_MAX
+#if defined(ARCH_ARM64) || defined(__aarch64__) || defined(ARCH_X64) || defined(__x86_64__)
+#define SIZE_MAX UINT64_MAX
+#else
+#define SIZE_MAX UINT32_MAX
+#endif
+#endif
 #ifndef WCHAR_MIN  /* also in wchar.h */ 
 #define WCHAR_MIN 0
 #define WCHAR_MAX ((wchar_t)-1) /* UINT16_MAX */

--- a/BaseHdr/va_list.h
+++ b/BaseHdr/va_list.h
@@ -50,6 +50,7 @@ extern "C"
 #endif
 
 
+#ifndef __GNUC__
 #define STACKITEM int
 
 #define VA_SIZE(TYPE)   \
@@ -63,6 +64,7 @@ extern "C"
 
 #define va_arg(AP, TYPE)  \
 	(AP += VA_SIZE(TYPE), *((TYPE *)(AP - VA_SIZE(TYPE))))
+#endif
 
 #endif
 


### PR DESCRIPTION
## Summary

This PR improves GCC compatibility for ARM64 by updating variadic argument handling, standardizing integer and pointer types for 64-bit targets, and introducing a small kernel-side enhancement required for user-space argument setup.

## Changes

### Variadic argument compatibility (`BaseHdr/stdarg.h`, `BaseHdr/va_list.h`)

- Use GCC built-in variadic argument support (`__builtin_va_list`, `__builtin_va_start`, `__builtin_va_arg`, `__builtin_va_end`) under `__GNUC__`.
- Preserve the existing MSVC implementation behind compiler guards.

**Why**

GCC on AArch64 follows the AAPCS64 ABI, where variadic arguments may reside in both registers and stack memory. Using the compiler-provided implementation ensures ABI compliance while keeping the existing MSVC behavior unchanged.

### Integer and pointer type standardization (`BaseHdr/stdint.h`)

- Standardize `intptr_t` and `uintptr_t` for 64-bit targets.
- Define `size_t` using the compiler-provided type under GCC.
- Update `SIZE_MAX` for proper 64-bit support.

**Why**

These changes improve cross-compiler consistency and avoid type mismatches when compiling GCC-based ARM64 code.

### User-space argument mapping (`BaseHdr/Hal/AA64/sched.h`)

- Add `argvkernel` to `AuUserEntry` alongside the existing user-space `argvaddr`.

**Why**

This allows the kernel to safely populate process arguments through its kernel mapping before transferring execution to user space.

## Compatibility

- Existing MSVC implementation remains unchanged.
- GCC-specific behavior is isolated behind compiler guards.
- Improves ARM64 GCC compatibility without affecting existing Windows/MSVC builds.

## Related

Part of #44