### PR TITLE
ARM64: Kernel Memory, PE Loader and VirtIO Stabilization

### DIFF
--- a/KernelAA64/Board/Virt/virt.c
+++ b/KernelAA64/Board/Virt/virt.c
@@ -78,7 +78,7 @@ void AuVirtIOInputInitialize() {
 				uint8_t sub_ClassCode = AuPCIERead(address, PCI_SUBCLASS, bus, dev, func);
 				uint16_t vendID = AuPCIERead(address, PCI_VENDOR_ID, bus, dev, func);
 				uint16_t devID = AuPCIERead(address, PCI_DEVICE_ID, bus, dev, func);
-				UARTDebugOut("Vendor ID attached : %x devID : %x \r\n", vendID, devID);
+				// UARTDebugOut("Vendor ID attached : %x devID : %x \r\n", vendID, devID);
 				if (vendID == 0x1AF4 && devID == 0x1052) {
 					uint8_t devType = AuVirtIOInputCheck(address, bus, dev, func);
 					if (devType == VIRTIO_INPUT_KEYBOARD) {

--- a/KernelAA64/Drivers/virtiokbd.c
+++ b/KernelAA64/Drivers/virtiokbd.c
@@ -113,6 +113,9 @@ void AuVirtioKbdHandler(int spinum) {
 }
 
 void AuVirtioKbdDown() {
+	if (!_kybrdCfg)
+		return;
+
 	/* Reset the device */
 	_kybrdCfg->DeviceStatus = 0;
 
@@ -184,6 +187,7 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	dsb_ish();
 
 	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)finalAddr;
+	_kybrdCfg = common;
 	common->DeviceStatus = 0;
 	
 	isb_flush();

--- a/KernelAA64/Drivers/virtiotablet.c
+++ b/KernelAA64/Drivers/virtiotablet.c
@@ -128,6 +128,9 @@ void AuVirtioTabletHandler(int spiNum) {
 }
 
 void AuVirtioTabletDown() {
+	if (!_tabletCfg)
+		return;
+
 	/* Reset the device */
     _tabletCfg->DeviceStatus = 0;
 
@@ -211,6 +214,7 @@ void AuVirtioTabletInitialize(uint64_t device) {
 	GICRegisterSPIHandler(&AuVirtioTabletHandler, spiID);
 
 	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)finalAddr;
+	_tabletCfg = common;
 	common->DeviceStatus = 0;
 	isb_flush();
 

--- a/KernelAA64/Hal/aa64lowlevel.s
+++ b/KernelAA64/Hal/aa64lowlevel.s
@@ -493,3 +493,10 @@ aa64_clean_invalidate_dcache:
    dsb sy
    isb
    ret
+
+.global aa64_invalidate_icache
+aa64_invalidate_icache:
+    ic ialluis
+    dsb ish
+    isb
+    ret

--- a/KernelAA64/KernelAA64.vcxproj
+++ b/KernelAA64/KernelAA64.vcxproj
@@ -199,7 +199,7 @@
       <AdditionalOptions> /def:exports.def %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)Build\EFI\XENEVA\$(TargetName).exe" "M:\EFI\XENEVA\$(TargetName).exe"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)Build\EFI\XENEVA\$(TargetName).exe" "M:\EFI\XENEVA\$(TargetName).exe" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/KernelAA64/Mm/pmmngr.c
+++ b/KernelAA64/Mm/pmmngr.c
@@ -301,9 +301,8 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 		pageCount = (dtb_end - dtb_start) / 0x1000;
 
 		for (int i = 0; i < pageCount; i++) {
-			uint64_t addr = dtb_start + (uint64_t)i * 0x1000; //  ((uint64_t)Address - UsablePhysicalMemory);
-			uint64_t Index = (addr - UsablePhysicalMemory);
-			AuPmmngrLockPage(Index);
+			uint64_t addr = dtb_start + (uint64_t)i * 0x1000;
+			AuPmmngrLockPage(addr);
 		
 		}
 
@@ -313,8 +312,7 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 		pageCount = (initrdEnd - initrdStart) / 0x1000;
 		for (int i = 0; i < pageCount; i++) {
 			uint64_t addr = initrdStart + (uint64_t)i * 0x1000;
-			uint64_t Index = (addr - UsablePhysicalMemory);
-			AuPmmngrLockPage(Index);
+			AuPmmngrLockPage(addr);
 		}
 	
 		uint64_t lbStart = lb->littleBootStart;
@@ -324,8 +322,7 @@ void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
 
 		for (int i = 0; i < pageCount; i++) {
 			uint64_t addr = lbStart + (uint64_t)i * 0x1000;
-			uint64_t Index = (addr - UsablePhysicalMemory);
-			AuPmmngrLockPage(Index);
+			AuPmmngrLockPage(addr);
 		}
 		AuTextOut("[aurora]: Pmmngr locked LittleBoot reserved memory\r\n");
 	}

--- a/KernelAA64/aucon.c
+++ b/KernelAA64/aucon.c
@@ -290,6 +290,16 @@ void AuPutPixel(size_t x, size_t y, uint32_t col) {
  * @param c -- character to print
  */
 void AuPutC(char c) {
+	if (early_) {
+		if (is_uart_initialized())
+			uartPutc(c);
+		else if (_print_func) {
+			char buf[2] = {c, 0};
+			_print_func(buf);
+		}
+		return;
+	}
+
 	if (console_x > v_res / 9) {
 		console_x = 0;
 		console_y++;
@@ -311,10 +321,12 @@ void AuPutC(char c) {
 	console_x++;
 
 	uint32_t* lfb = aucon->buffer;
-	if (console_y + 1 > h_res / 16)
+	if (console_y + 1 > v_res / 16)
 	{
-		for (int i = 16; i < h_res * v_res; i++)
-			lfb[i] = lfb[i + v_res * 16];
+		for (int i = 0; i < (v_res - 16) * h_res; i++)
+			lfb[i] = lfb[i + h_res * 16];
+		for (int i = (v_res - 16) * h_res; i < v_res * h_res; i++)
+			lfb[i] = CONSOLE_BACKGROUND;
 		console_y--;
 	}
 
@@ -327,6 +339,14 @@ void AuPutC(char c) {
  * @param str -- string to print
  */
 void AuPutS(char* str) {
+	if (early_) {
+		if (is_uart_initialized())
+			uartPuts(str);
+		else if (_print_func)
+			_print_func(str);
+		return;
+	}
+	
 	uint32_t* lfb = aucon->buffer;
 	while (*str) {
 
@@ -373,8 +393,10 @@ void AuPutS(char* str) {
 	/* Scroll */
 	if (console_y + 1 > v_res / 16)
 	{
-		for (int i = 16; i < v_res * h_res; i++)
+		for (int i = 0; i < (v_res - 16) * h_res; i++)
 			lfb[i] = lfb[i + h_res * 16];
+		for (int i = (v_res - 16) * h_res; i < v_res * h_res; i++)
+			lfb[i] = CONSOLE_BACKGROUND;
 		console_y--;
 	}
 }
@@ -385,13 +407,6 @@ void AuPutS(char* str) {
  * @param text -- text to output
  */
 void AuTextOut(const char* format, ...) {
-	if (early_) {
-		if (is_uart_initialized())
-			UARTDebugOut(format);
-		else
-			_print_func(format);
-		return;
-	}
 	if (bypass_autextout)
 		return;
 

--- a/KernelAA64/init.c
+++ b/KernelAA64/init.c
@@ -288,10 +288,10 @@ void _AuMain(KERNEL_BOOT_INFO* info) {
 	
 	AuProcess* proc = AuCreateProcessSlot(0, "exec");
 	int num_args = 1;
-	char* about = (char*)kmalloc(strlen("-about"));
+	char* about = (char*)kmalloc(strlen("-about") + 1);
 	strcpy(about, "-about");
 	char** argvs = (char**)kmalloc(num_args * sizeof(char*));
-	memset(argvs, 0, num_args);
+	memset(argvs, 0, num_args * sizeof(char*));
 	argvs[0] = about;
 
 	/** make init process, as root of all */

--- a/KernelAA64/loader.c
+++ b/KernelAA64/loader.c
@@ -87,36 +87,56 @@ void AuProcessEntUser(uint64_t rcx) {
 	uentry->rsp -= 32;
 	PUSHALIGN(uentry->rsp, 16);
 	t->first_run = 1;
-	/* do all arguments passing stuff, arguments
-	 * are passed as strings to stack
+
+	/*
+	 * ARM64 ABI: argc and argv must be placed on the user stack so that
+	 * crt0arm64.s can pop them via: ldp x0, x1, [sp], #16
+	 *
+	 * Step 1: Push each argument string onto the user stack (grow downward).
+	 *         Record the resulting user-space SP as argv[i] in the
+	 *         user-mapped argvaddr page.
+	 * Step 2: Push argc and argv_ptr (argvaddr) onto the user stack.
+	 * Step 3: Free kernel-side copies AFTER we have finished reading them.
 	 */
 
-	char** argvs = (char**)uentry->argvaddr;
-	for (int i = 0; i < uentry->num_args; i++) {
+	/* Step 1 — push strings and record user-space pointers */
+	char** argvs = (char**)uentry->argvkernel;  /* kernel-accessible VA of argv[] page */
+	for (int i = uentry->num_args - 1; i >= 0; i--) {
 		char* str = uentry->argvs[i];
-		for (int j = strlen(str); j >= 0; j--) {
+		int slen = strlen(str);
+		/* push null terminator first, then chars in reverse so string
+		 * reads forward at lower address after push */
+		PUSH(uentry->rsp, char, '\0');
+		for (int j = slen - 1; j >= 0; j--) {
 			PUSH(uentry->rsp, char, str[j]);
 		}
+		/* record the user-space address of this string */
 		argvs[i] = (char*)uentry->rsp;
 	}
 
-	/* I think this code should be placed in _KeProcessExit */
+	/* Step 2 — align, then push argv_ptr and argc */
+	PUSHALIGN(uentry->rsp, 16);
+	PUSH(uentry->rsp, size_t, (size_t)uentry->argvaddr);  /* x1 = argv */
+	PUSH(uentry->rsp, size_t, (size_t)uentry->num_args);  /* x0 = argc */
+	PUSHALIGN(uentry->rsp, 16);
+
+	/* Step 3 — free kernel-side argv copies (no longer needed) */
 	if (uentry->argvs) {
 		for (int i = 0; i < uentry->num_args; i++) {
-			//uint64_t addr = (uint64_t)uentry->argvs[i];
 			kfree(uentry->argvs[i]);
 		}
-		void* address = (void*)uentry->argvs;
-		kfree(address);
+		kfree(uentry->argvs);
 	}
-	PUSHALIGN(uentry->rsp, 16);
 	uentry->argvs = 0;
-	PUSH(uentry->rsp, size_t, (size_t)uentry->argvaddr);
-	PUSH(uentry->rsp, size_t, (size_t)uentry->num_args);
-	PUSHALIGN(uentry->rsp, 16);
+
+	UARTDebugOut("[loader]: entering user: sp=%x entry=%x argc=%d argv=%x\r\n",
+		uentry->rsp, uentry->entrypoint, uentry->num_args, uentry->argvaddr);
+
+	uint64_t* check_sp = (uint64_t*)uentry->rsp;
+	UARTDebugOut("[loader]: stack check [0]: %x, [1]: %x\r\n", check_sp[0], check_sp[1]);
+
 	aa64_enter_user(uentry->rsp, uentry->entrypoint);
-	while (1) {
-	}
+	while (1) {}
 }
 
 /**
@@ -134,37 +154,42 @@ void AuLoaderMapExecFromCache(AuProcess* proc, AuMMFileBack *fb,PIMAGE_NT_HEADER
 		UARTDebugOut("Name : %s \r\n", fb->file->filename);
 	for (size_t i = 0; i < nt->FileHeader.NumberOfSections; ++i) {
 		size_t load_addr = _image_base_ + secthdr[i].VirtualAddress;
-		void* sect_addr = (void*)load_addr;
-		size_t sectsz = secthdr[i].VirtualSize;
-		int req_pages = sectsz / 4096 +
-			((sectsz % 4096) ? 1 : 0);
-		uint64_t* block = 0;
-		int physFrameIndex = 0;
-		size_t rawSize = secthdr[i].SizeOfRawData;
 		size_t virtSize = secthdr[i].VirtualSize;
+		size_t rawSize = secthdr[i].SizeOfRawData;
 		size_t fileOffset = secthdr[i].PointerToRawData;
-		int page_index = fileOffset / PAGE_SIZE;
-		AuMMPageCache* cache = AuMmngrFileCacheGetByIndex(fb, page_index);
-		if (secthdr[i].Characteristics & IMAGE_SCN_MEM_WRITE) {
-			for (int j = 0; j < req_pages; j++) {
-				uint64_t alloc = (load_addr + j * 0x1000);
-					uint64_t phys = P2V((size_t)AuPmmngrAlloc());
-					AuMapPageEx(proc->cr3, V2P(phys), alloc, PTE_USER_EXECUTABLE | PTE_AP_RW_USER | PTE_NORMAL_MEM);
-					if (!block)
-						block = (uint64_t*)phys;
-					memcpy(phys, (void*)P2V(cache->physicalPage), PAGE_SIZE);
-				physFrameIndex++;
-				cache = cache->next;
+
+		/* Ensure all pages for this section's virtual address range are mapped */
+		size_t end_addr = load_addr + virtSize;
+		for (size_t v_page = (load_addr & ~0xFFFULL); v_page < end_addr; v_page += PAGE_SIZE) {
+			void* phys = AuGetPhysicalAddressEx(proc->cr3, v_page);
+			if (!phys) {
+				phys = AuPmmngrAlloc();
+				memset((void*)P2V((size_t)phys), 0, PAGE_SIZE);
+				AuMapPageEx(proc->cr3, (uint64_t)phys, v_page, PTE_USER_EXECUTABLE | PTE_AP_RW_USER | PTE_NORMAL_MEM);
 			}
 		}
-		else {
-			for (int j = 0; j < req_pages; j++) {
-				uint64_t alloc = (load_addr + j * 0x1000);
-				uint64_t phys = cache->physicalPage; //P2V((size_t)AuPmmngrAlloc());
-				AuMapPageEx(proc->cr3, phys, alloc, PTE_USER_EXECUTABLE | PTE_AP_RW_USER | PTE_NORMAL_MEM);
-				physFrameIndex++;
-				cache = cache->next;
+
+		/* Copy data from the scratch buffer to the mapped pages, handling boundaries */
+		size_t bytes_to_copy = rawSize;
+		size_t current_vaddr = load_addr;
+		size_t current_file_offset = fileOffset;
+		while (bytes_to_copy > 0) {
+			size_t page_offset = current_vaddr & 0xFFF;
+			size_t bytes_in_this_page = PAGE_SIZE - page_offset;
+			if (bytes_in_this_page > bytes_to_copy) {
+				bytes_in_this_page = bytes_to_copy;
 			}
+			
+			void* phys = AuGetPhysicalAddressEx(proc->cr3, current_vaddr);
+			if (phys) {
+				void* dest = (void*)(P2V((size_t)phys) + page_offset);
+				void* src = (void*)((uint64_t)_ldr_scratchBuffer + current_file_offset);
+				memcpy(dest, src, bytes_in_this_page);
+			}
+			
+			current_vaddr += bytes_in_this_page;
+			current_file_offset += bytes_in_this_page;
+			bytes_to_copy -= bytes_in_this_page;
 		}
 	}
 }
@@ -267,7 +292,7 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 	PIMAGE_NT_HEADERS nt = RAW_OFFSET(PIMAGE_NT_HEADERS,dos, dos->e_lfanew);
 	PSECTION_HEADER secthdr = RAW_OFFSET(PSECTION_HEADER,&nt->OptionalHeader, nt->FileHeader.SizeOfOptionaHeader);
 
-	uint64_t _image_base_ = 0x60000000000;//   nt->OptionalHeader.ImageBase;
+	uint64_t _image_base_ = 0x600000000;//   nt->OptionalHeader.ImageBase;
 	entry ent = (entry)(nt->OptionalHeader.AddressOfEntryPoint + _image_base_);//nt->OptionalHeader.ImageBase);
 	//AuTextOut("Image base address : %x \n", dos->e_magic);
 	uint64_t* cr3 = proc->cr3;
@@ -344,19 +369,23 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 	uentry->stackBase = proc->_main_stack_;
 	int num_args = argc;
 	uint64_t argvaddr = 0;
+	uint64_t argvkernel = 0;
 	if (num_args) {
 		/* Allocate a memory for passing arguments */
 		uint64_t* args = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
 		memset(args, 0, PAGE_SIZE);
-		if (!AuMapPageEx(proc->cr3, (size_t)V2P((uint64_t)args), 0x40000000000,PTE_AP_RW_USER | PTE_NORMAL_MEM)) {
+		if (!AuMapPageEx(proc->cr3, (size_t)V2P((uint64_t)args), 0x40000000000, PTE_AP_RW_USER | PTE_NORMAL_MEM)) {
 			UARTDebugOut("Arguments address already mapped \n");
 			argvaddr = 0;
+			argvkernel = 0;
 		}
 		else {
-			argvaddr = 0x40000000000;
+			argvaddr = 0x40000000000;  /* user-space VA for crt0 */
+			argvkernel = (uint64_t)args; /* kernel-space VA for AuProcessEntUser to write */
 		}
 	}
 	uentry->argvaddr = argvaddr;
+	uentry->argvkernel = argvkernel;
 	uentry->num_args = num_args;
 	uentry->argvs = argv;
 	thr->uentry = uentry;

--- a/KernelAA64/process.c
+++ b/KernelAA64/process.c
@@ -395,7 +395,7 @@ void AuProcessFreeKeResource(AA64Thread* thr) {
  * @param proc -- process to exit
  * @param schedulable -- schedule to next thread
  */
-void AuProcessExit(AuProcess* proc, bool schedulable) {
+void AuProcessExit(AuProcess* proc, BOOL schedulable) {
 	if (proc == root_proc) {
 		UARTDebugOut("[aurora]: cannot exit root process \r\n");
 		return;


### PR DESCRIPTION
## Summary
This PR continues the ARM64 bring-up effort by addressing stability and correctness issues in kernel memory management, the PE loader, ARM64 ABI handling, and VirtIO.

The changes focus on improving GCC/ARM64 compatibility while preserving existing MSVC behavior wherever possible. Existing MSVC code paths were intentionally left unchanged unless their behavior could be verified.

## Changes

### PE Loader (`loader.c`)
- **Before:** Section mapping blindly allocated blocks, which could lead to translation faults for unaligned sections. User-space `argc`/`argv` were also laid out using assumptions that did not match the ARM64 `crt0` ABI.
- **What:** Implemented page-boundary-safe section mapping and reworked the user-space `argc`/`argv` stack layout to follow the ARM64 `crt0` ABI (`ldp x0, x1`).
- **Why:** Prevents translation faults caused by unaligned section mappings and ensures user processes receive arguments in the expected ARM64 ABI layout.

### Physical Memory (`pmmngr.c`)
- **Before:** Physical page locking used relative offsets instead of absolute physical addresses for DTB, InitRD, and LittleBoot reserved regions.
- **What:** Corrected physical page locking by passing absolute physical addresses.
- **Why:** Ensures reserved boot-time memory regions are correctly marked as in use and are not reused by the physical memory manager.

### Console (`aucon.c`)
- **Before:** The scrolling logic performed incorrect boundary validation and did not properly clear the bottom framebuffer region.
- **What:** Fixed scrolling boundary validation and framebuffer clearing logic.
- **Why:** Prevents out-of-bounds framebuffer access during console scrolling.

### Process Initialization (`init.c`)
- **Before:** Argument allocation omitted the null terminator, and the argument pointer array was not fully initialized.
- **What:** Added the missing null terminator and properly initialized the argument pointer memory.
- **Why:** Prevents silent memory corruption during process initialization.

### VirtIO (`virt.c`, `virtiokbd.c`, `virtiotablet.c`)
- **Before:** Excessive UART debug output reduced boot log readability, and device teardown paths could dereference null pointers.
- **What:** Reduced unnecessary UART debug output and added null pointer safety checks during device teardown.
- **Why:** Improves boot diagnostics and prevents invalid pointer access during early device shutdown.

### ARM64 Low-Level (`aa64lowlevel.s`)
- **Before:** Newly loaded executable code could execute before instruction cache synchronization.
- **What:** Added an explicit instruction cache invalidation routine (`aa64_invalidate_icache`) after executable code loading.
- **Why:** Ensures instruction cache coherency on ARM64 before transferring execution to newly loaded code.

### Compiler Compatibility (`process.c`)
- **Before:** Boolean usage relied on compiler-specific behavior across supported toolchains.
- **What:** Replaced compiler-dependent boolean usage with explicit `BOOL` types where appropriate.
- **Why:** Improves consistency across supported compilers while preserving existing behavior.

## Compatibility
- [x] Existing functionality is preserved except for the fixes described above.
- [x] Existing MSVC behavior has been preserved where possible.
- [x] GCC compatibility has been improved.
- [x] No intentional regression in bootloader, kernel, or user-space runtime logic.

## Related
Part of #44