### PR TITLE
fix(runtime): stabilize user-space runtime and ARM64 entry points

### DIFF
--- a/Process/DeodhaiAudio/audmain.cpp
+++ b/Process/DeodhaiAudio/audmain.cpp
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <sys/_keproc.h>
 #include <sys/_kefile.h>
-#include <sys/mman.h>>
+#include <sys/mman.h>
 #include <sys/iocodes.h>
 #include <string.h>
 #include <stdlib.h>

--- a/Process/DeodhaiXR/_fastcpy_arm64.s
+++ b/Process/DeodhaiXR/_fastcpy_arm64.s
@@ -49,8 +49,8 @@ _fastcpy:
     b.lt .byte_loop
 
 .blk16_loop:
-    ldp q0, q1,[x1], #16
-    stp q0,q1,[x0],#16
+    ldr q0,[x1], #16
+    str q0,[x0],#16
     sub x2, x2, #16
     cmp x2, #16
     b.ge .blk16_loop

--- a/Process/DeodhaiXR/crt_arm64.s
+++ b/Process/DeodhaiXR/crt_arm64.s
@@ -1,0 +1,10 @@
+.extern main
+.extern _KeProcessExit
+
+.global _aumain
+_aumain:
+     ldp x0,x1, [sp], #16
+	 sub sp, sp,32
+	 bl main
+	 add sp, sp,32
+	 bl _KeProcessExit


### PR DESCRIPTION
## Summary

This Pull Request stabilizes the user-space runtime, low-level ARM64 assembly, and startup entry points for the display server/compositor and related daemons on GCC/AArch64 builds.

## Changes

### DeodhaiAudio (Audio Daemon)
- **Before:** `Process/DeodhaiAudio/audmain.cpp` contained an invalid include directive (`#include <sys/mman.h>>`) with a trailing `>`.
- **What:** Removed the extra `>` from the include directive.
- **Why:** GCC rejects the invalid preprocessor syntax, preventing successful compilation.

### DeodhaiXR Assembly (Fast Copy)
- **Before:** `Process/DeodhaiXR/_fastcpy_arm64.s` used `ldp q0, q1, [x1], #16`, loading 32 bytes while advancing the pointer by only 16 bytes.
- **What:** Replaced the paired load/store sequence with the appropriate single-register load/store instructions (`ldr`/`str`).
- **Why:** Corrects the copy logic and prevents memory corruption caused by overlapping memory accesses on ARM64.

### DeodhaiXR Startup (ARM64 Runtime)
- **Before:** GCC/AArch64 builds lacked the required user-space startup entry point for DeodhaiXR.
- **What:** Added `Process/DeodhaiXR/crt_arm64.s` implementing the `_aumain` startup entry.
- **Why:** Initializes the ARM64 user-space runtime, transfers control to `main`, and terminates cleanly through `_KeProcessExit`.

## Compatibility

- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [x] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.

## Related

Part of #44