### PR TITLE
gcc: improve user-space compatibility and Linux build workflow

### DIFF
--- a/Process/Control/ctrl.cpp
+++ b/Process/Control/ctrl.cpp
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
        "making  them a \nfull-fledged standalone device capable of replacing smartphones by doing everything \nthey do.";
 	char* android = "We're working towards adding an Android Compatibility Layer which will bring support for all"
 		" android apps on XenevaOS.";
-	char* default = "Default text for Control App ";
+	char* default_text = "Default text for Control App ";
 	if (argc > 1) {
 		char* param = argv[1];
 		if (strcmp(param, "about") == 0) {
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
 			_add_buttons = false;
 		}
 		else if (strcmp(param, "default") == 0) {
-			ChTextBoxSetText(tb, default);
+			ChTextBoxSetText(tb, default_text);
 			_add_buttons = false;
 		}
 	}

--- a/Process/DeodhaiXR/window.cpp
+++ b/Process/DeodhaiXR/window.cpp
@@ -122,8 +122,8 @@ Window* CreateWindow(int x, int y, int w, int h, uint16_t flags, uint16_t ownerI
 	win->backBufferKey = backBufferKey;
 	win->sharedInfo = CreateSharedWinSpace(&shKey, ownerId);
 	win->shWinKey = shKey;
-	win->title = (char*)malloc(strlen(title));
-	memset(win->title, 0, strlen(title));
+	win->title = (char*)malloc(strlen(title) + 1);
+	memset(win->title, 0, strlen(title) + 1);
 	strcpy(win->title, title);
 	WinSharedInfo* shwin = (WinSharedInfo*)win->sharedInfo;
 	shwin->x = x;

--- a/Scripts/Linux/build_and_run_qemu.sh
+++ b/Scripts/Linux/build_and_run_qemu.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 set -e
 
-# Check for manual build flag
-FORCE_MANUAL_BUILD=0
-if [ "$1" == "--force-manual-build" ]; then
-    FORCE_MANUAL_BUILD=1
+# Check for legacy build flag
+FORCE_LEGACY_BUILD=0
+if [ "$1" == "--force-legacy-build" ]; then
+    FORCE_LEGACY_BUILD=1
 fi
-
 
 echo "[+] Creating 512MB FAT32 image..."
 dd if=/dev/zero of=fat.img bs=1M count=512
@@ -17,9 +16,9 @@ mmd -i fat.img ::/EFI
 mmd -i fat.img ::/EFI/BOOT
 mmd -i fat.img ::/EFI/XENEVA
 
-# [Note: (Temporary Dev Workaround)
-# During the active porting phase, you can place a pre-built initrd2.img
-# (with GUI/resources) at the root of the repository to skip manual building.
+# [Note: The default script will always build initrd2.img and pack resources.
+# Using a pre-built legacy initrd2.img is NOT RECOMMENDED, but can be forced
+# by passing the --force-legacy-build flag.
 # Example Directory Structure:
 #   XenevaOS/
 #   ├── KernelAA64/
@@ -27,7 +26,7 @@ mmd -i fat.img ::/EFI/XENEVA
 #   ├── Scripts/
 #   └── initrd2.img   <-- Place it exactly here
 # ]
-if [ "$FORCE_MANUAL_BUILD" -eq 1 ] || [ ! -f "initrd2.img" ]; then
+if [ "$FORCE_LEGACY_BUILD" -eq 0 ]; then
     echo "[+] Creating 64MB FAT32 initrd2.img and packing resources..."
     dd if=/dev/zero of=initrd2.img bs=1M count=64
     mkfs.vfat -F 32 initrd2.img


### PR DESCRIPTION
## Summary

This Pull Request improves GCC/Linux compatibility by resolving user-space compilation issues, fixing a memory safety bug, and refining the Linux build workflow used during the ARM64 bring-up effort.

## Changes

### Control (`Process/Control/ctrl.cpp`)
- **Before:** The code used an identifier (`default`) that conflicted with standard C++ parsing.
- **What:** Renamed the identifier to `default_text`.
- **Why:** Restores successful compilation under GCC without changing runtime behavior.

### DeodhaiXR (`Process/DeodhaiXR/window.cpp`)
- **Before:** Window title allocation did not reserve space for the null terminator.
- **What:** Updated the allocation and initialization logic to use `strlen(title) + 1`.
- **Why:** Prevents off-by-one writes and potential heap corruption when setting window titles.

### Linux Build Script (`Scripts/Linux/build_and_run_qemu.sh`)
- **Before:** The build script relied on the legacy workflow by default.
- **What:** Updated the default workflow to prioritize fresh `initrd2.img` generation and added a `--force-legacy-build` override.
- **Why:** Improves the default Linux build workflow while preserving the legacy path when explicitly requested.

## Compatibility

- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [x] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.

## Related

Part of #44