### PR TITLE
build(msvc): standardize PostBuildEvent deployment logic across all kernel drivers

### DIFF
--- a/Drivers/AHCI/AHCI.vcxproj
+++ b/Drivers/AHCI/AHCI.vcxproj
@@ -150,7 +150,7 @@
       <DataExecutionPrevention />
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/Drivers/E1000/E1000.vcxproj
+++ b/Drivers/E1000/E1000.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -120,7 +120,7 @@
       <AdditionalOptions>/ALIGN:512</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/GPU/virtiogpu/virtiogpu.vcxproj
+++ b/Drivers/GPU/virtiogpu/virtiogpu.vcxproj
@@ -187,7 +187,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/NVMe/NVMe.vcxproj
+++ b/Drivers/NVMe/NVMe.vcxproj
@@ -117,7 +117,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/Net/virtionet/virtionet.vcxproj
+++ b/Drivers/Net/virtionet/virtionet.vcxproj
@@ -192,7 +192,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/Sound/IntelHDA/IntelHDA.vcxproj
+++ b/Drivers/Sound/IntelHDA/IntelHDA.vcxproj
@@ -119,7 +119,7 @@
       <AdditionalOptions>/ALIGN:512</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "..\..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/Sound/virtiosnd/virtiosnd.vcxproj
+++ b/Drivers/Sound/virtiosnd/virtiosnd.vcxproj
@@ -192,7 +192,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/USB/dwc2-otg/dwc2-otg.vcxproj
+++ b/Drivers/USB/dwc2-otg/dwc2-otg.vcxproj
@@ -192,7 +192,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/USB/dwc2-uspi/dwc2-uspi.vcxproj
+++ b/Drivers/USB/dwc2-uspi/dwc2-uspi.vcxproj
@@ -192,7 +192,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/USB/hid/hid.vcxproj
+++ b/Drivers/USB/hid/hid.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -118,7 +118,7 @@
       <AdditionalOptions>/ALIGN:512 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/USB/msc/msc.vcxproj
+++ b/Drivers/USB/msc/msc.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -118,7 +118,7 @@
       <AdditionalOptions>/ALIGN:512 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/USB/usbhci/usbhci.vcxproj
+++ b/Drivers/USB/usbhci/usbhci.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -118,7 +118,7 @@
       <AdditionalOptions>/ALIGN:512 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
-      <Command>copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll</Command>
+      <Command>if exist M:\ ( copy "..\..\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/fbset/lcdif/lcdif.vcxproj
+++ b/Drivers/fbset/lcdif/lcdif.vcxproj
@@ -192,7 +192,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/hdmi/hdmi.vcxproj
+++ b/Drivers/hdmi/hdmi.vcxproj
@@ -192,7 +192,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/Drivers/virtioblk/virtioblk.vcxproj
+++ b/Drivers/virtioblk/virtioblk.vcxproj
@@ -187,7 +187,7 @@
       <FixedBaseAddress>false</FixedBaseAddress>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll"</Command>
+      <Command>if exist M:\ ( copy "$(SolutionDir)\Build\$(TargetName).dll" "M:\$(TargetName).dll" ) else ( echo M: drive not found, skipping copy )</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">


### PR DESCRIPTION
## Summary

This Pull Request standardizes the MSVC `PostBuildEvent` deployment logic across all kernel driver projects by introducing consistent guarded copy commands and correcting project file syntax issues.

## Changes

### Kernel Driver MSVC Projects

- **Before:** Several driver projects used unguarded post-build copy commands and contained inconsistent command syntax, which could cause build failures when the `M:\` deployment drive was unavailable.
- **What:** Updated the affected driver `.vcxproj` files to:
  - Standardize the guarded `PostBuildEvent` deployment logic using `if exist M:\ (...)`.
  - Correct quotation and command syntax inconsistencies in the post-build copy commands.
- **Why:** Improves build robustness and ensures consistent deployment behavior across all kernel driver projects without affecting normal MSVC workflows.

## Compatibility

- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [x] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.