### PR TITLE
fix(kernel,boot): improve GCC/Clang compatibility across kernel and boot components

### DIFF
--- a/BaseHdr/Hal/x86_64_gdt.h
+++ b/BaseHdr/Hal/x86_64_gdt.h
@@ -31,7 +31,11 @@
 #define __X86_64_GDT_H__
 
 #include <stdint.h>
+#if defined(__GNUC__) || defined(__clang__)
+#ifndef __cplusplus
 #include <stddef.h>
+#endif
+#endif
 
 #define GDT_ENTRY_NULL 0
 #define GDT_ENTRY_KERNEL_CODE 1

--- a/BaseHdr/timer.h
+++ b/BaseHdr/timer.h
@@ -33,7 +33,11 @@
 #define __TIMER_H__
 
 #include <aurora.h>
+#ifdef ARCH_X64
+#include <Hal/x86_64_sched.h>
+#elif ARCH_ARM64
 #include <Hal/AA64/sched.h>
+#endif
 #if defined(__GNUC__) || defined(__clang__)
 #ifndef __cplusplus
 #include <stdbool.h>

--- a/Boot/xnldr.cpp
+++ b/Boot/xnldr.cpp
@@ -260,7 +260,7 @@ EFI_STATUS efi_main_handler(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemTabl
 	 *-------------------------------------------------------------------
 	 */
 	void* xdsp_address = NULL;
-#ifdef __MSC_VER
+#ifdef _MSC_VER
 	static EFI_GUID acpi_guid = EFI_ACPI_20_TABLE_GUID;
 #else
 	static EFI_GUID acpi_guid = ACPI_20_TABLE_GUID; 

--- a/BootAA64/Makefile
+++ b/BootAA64/Makefile
@@ -1,4 +1,5 @@
 # Target EFI binary
+.DEFAULT_GOAL := all
 TARGET_EFI = BOOTAA64.efi
 TARGET_SO = BOOTAA64.so
 
@@ -84,7 +85,7 @@ $(EFI_OUTPUT): $(OBJS)
 else
 # Original GCC compilation
 $(SO_OUTPUT): $(CRT0) $(OBJS)
-	$(LD) -nostdlib --warn-common --no-undefined --build-id=sha1 -z noexecstack -z max-page-size=4096 \
+	$(LD) -nostdlib --warn-common --no-undefined --build-id=sha1 -z muldefs -z noexecstack -z max-page-size=4096 \
 	-shared -Bsymbolic $(LIBDIRS) -T$(LDSCRIPT) $(CRT0) $(OBJS) -o $@ $(LIBS)
 
 $(EFI_OUTPUT): $(SO_OUTPUT)

--- a/BootAA64/xnldr.h
+++ b/BootAA64/xnldr.h
@@ -34,7 +34,11 @@
 
 #include <stdint.h>
 #include <Uefi.h>
+#if defined(__GNUC__) || defined(__clang__)
+#ifndef __cplusplus
 #include <stddef.h>
+#endif
+#endif
 #ifndef SIZE_MAX
 #if defined(ARCH_ARM64) || defined(ARCH_X64) || defined(_M_AMD64) || defined(_M_ARM64) || defined(__x86_64__) || defined(__aarch64__)
 #define SIZE_MAX 0xFFFFFFFFFFFFFFFFULL

--- a/Kernel/Hal/serial.cpp
+++ b/Kernel/Hal/serial.cpp
@@ -80,7 +80,7 @@ void DebugSerial(char* string) {
  */
 AU_EXTERN AU_EXPORT void SeTextOut(char* format, ...) {
 
-	_va_list_ args;
+	va_list args;
 	va_start(args, format);
 
 	while (*format)

--- a/Kernel/_CRT.cpp
+++ b/Kernel/_CRT.cpp
@@ -30,7 +30,11 @@
 
 
 #include <stdint.h>
+#if defined(__GNUC__) || defined(__clang__)
+#ifndef __cplusplus
 #include <stddef.h>
+#endif
+#endif
 
 extern "C" int _fltused = 1;
 

--- a/Kernel/process.cpp
+++ b/Kernel/process.cpp
@@ -407,7 +407,7 @@ int AuProcessWaitForTermination(AuProcess *proc, int pid) {
 	else {
 		AuProcess* proc = AuProcessFindByPID(0,pid);
 		if (!proc)
-			return;
+			return -1;
 		AuThread* thr = AuGetCurrentThread();
 		AuBlockThread(thr);
 		list_add(proc->waitlist, thr);

--- a/KernelAA64/Makefile
+++ b/KernelAA64/Makefile
@@ -1,4 +1,5 @@
 # XenevaOS KernelAA64 Makefile
+.DEFAULT_GOAL := all
 
 TARGET = KernelAA64.elf
 OBJDIR = obj

--- a/KernelAA64/init.c
+++ b/KernelAA64/init.c
@@ -69,7 +69,6 @@
 #include <Fs/Fat/Fat.h>
 #include <Fs/Fat/FatFile.h>
 #include <Fs/Fat/FatDir.h>
-#include <linux/bitops.h>
 
 extern int _fltused = 1;
 static bool _littleboot_used;

--- a/KernelAA64/process.c
+++ b/KernelAA64/process.c
@@ -402,7 +402,7 @@ void AuProcessFreeKeResource(AA64Thread* thr) {
  * @param proc -- process to exit
  * @param schedulable -- schedule to next thread
  */
-void AuProcessExit(AuProcess* proc, BOOL schedulable) {
+void AuProcessExit(AuProcess* proc, bool schedulable) {
 	if (proc == root_proc) {
 		UARTDebugOut("[aurora]: cannot exit root process \r\n");
 		return;
@@ -515,7 +515,7 @@ int AuProcessWaitForTermination(AuProcess* proc, int pid) {
 	else {
 		AuProcess* proc = AuProcessFindByPID(0, pid);
 		if (!proc)
-			return;
+			return -1;
 		AA64Thread* thr = AuGetCurrentThread();
 		AuBlockThread(thr);
 		list_add(proc->waitlist, thr);

--- a/Process/DeodhaiXR/alpha.cpp
+++ b/Process/DeodhaiXR/alpha.cpp
@@ -32,7 +32,9 @@
 #include "deodxr.h"
 #include "alpha.h"
 #if defined(ARCH_ARM64)
+#ifdef ARCH_ARM64
 #include <arm_neon.h>
+#endif
 #endif
 #include <math.h>
 #include "window.h"

--- a/Process/DeodhaiXR/main.cpp
+++ b/Process/DeodhaiXR/main.cpp
@@ -51,7 +51,9 @@
 #include "animation.h"
 #include "alpha.h"
 #include "nanojpg.h"
+#ifdef ARCH_ARM64
 #include <arm_neon.h>
+#endif
 #include "compose.h"
 #include <sys/_ketime.h>
 

--- a/Process/XELnch/rrect.cpp
+++ b/Process/XELnch/rrect.cpp
@@ -1,4 +1,6 @@
-﻿#include <arm_neon.h>
+#ifdef ARCH_ARM64
+#include <arm_neon.h>
+#endif
 #include <stdint.h>
 #include <chitralekha.h>
 


### PR DESCRIPTION
## Summary

This PR addresses a set of GCC/Clang compatibility issues across the kernel, bootloader, and AArch64 build system while preserving the existing implementation where possible. The changes focus on resolving compiler-specific incompatibilities, correcting build configuration, and improving cross-toolchain portability.

## Changes

### Kernel
- **Before:** Some source files relied on compiler-specific types, contained invalid return statements, or included headers that caused portability issues with GCC/Clang.
- **What:** Added compiler and architecture guards where required, replaced compiler-specific variadic types with standard `va_list`, corrected non-void return paths, and removed an unnecessary host Linux header dependency.
- **Why:** Improve compatibility with GCC/Clang while preserving existing behavior.

### Bootloader
- **Before:** The bootloader contained an incorrect MSVC compiler macro check and required updates for the GCC/Clang toolchain.
- **What:** Corrected the `_MSC_VER` preprocessor check and updated the AArch64 bootloader build configuration.
- **Why:** Improve compiler compatibility and maintain consistent build behavior across supported toolchains.

### Build System
- **Before:** Default build target selection and AArch64 build configuration were not aligned with the intended GCC workflow.
- **What:** Updated the AArch64 Makefiles to use the intended default build target and adjusted linker/build configuration where required.
- **Why:** Improve build consistency for GCC/Clang-based development.

## Compatibility

- [x] Existing functionality is intended to remain unchanged.
- [ ] MSVC/Windows build verification pending.
- [x] GCC/Linux build completed successfully.
- [x] ARM64 runtime validated.

## Related

Part of #44