### PR TITLE
PDMap, buddy allocator, documentation, build scripts, bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,12 @@ Debug/
 Release/
 KernelAA64/*.elf
 KernelAA64/*.exe
+KernelAA64/*.lib
 KernelAA64/*.log
 KernelAA64/obj/
 fat.img
 initrd2.img
+fat-*.img
 qemu.pid
 dump.s
 *.so
@@ -49,6 +51,9 @@ Libs/**/*.a
 # Exclude compiled user-space applications
 Resources/resources/*.exe
 Resources/resources/ARCH_ARM64/*.exe
+
+# One-off debug/comparison binaries from investigation sessions, not regular build output
+/KernelAA64-*.exe
 
 # clangd / IDE tooling (regenerate via Scripts/Linux/gen_compile_commands.sh)
 compile_commands.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "MicroPython (Emulator)",
+            "type": "micropython-emulator",
+            "request": "launch",
+            "program": "${file}"
+        },
+        {
+            "name": "Python: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/BaseHdr/Fs/vdisk.h
+++ b/BaseHdr/Fs/vdisk.h
@@ -56,6 +56,15 @@ struct _VDISK_;
 
 typedef int(*vdisk_read) (struct _VDISK_ *disk, uint64_t lba, uint32_t count ,uint64_t* buffer);
 typedef int(*vdisk_write) (struct _VDISK_ *disk, uint64_t lba, uint32_t count, uint64_t *buffer);
+/* driver-level write-cache flush (VIRTIO_BLK_T_FLUSH / ATA_CMD_CACHE_FLUSH
+ * type thing), left NULL by drivers that dont implement one yet. added at
+ * the end of AuVDisk so existing field offsets dont move, but every
+ * AuVDiskRegister() caller still has to get its struct from
+ * AuCreateVDisk() (kernel-side alloc+memset, so this field comes back
+ * NULL) instead of kmalloc'ing or declaring its own AuVDisk. otherwise a
+ * driver built against an older copy of this header leaves Flush
+ * uninitialized and AuVDiskFlushAll() jumps to garbage on shutdown --axiss */
+typedef int(*vdisk_flush) (struct _VDISK_ *disk);
 
 /* will needed in future */
 typedef struct _au_partition_data_ {
@@ -103,7 +112,8 @@ typedef struct _VDISK_ {
 	//=======================//
 	vdisk_read Read;
 	vdisk_write Write;
-	/* more device specific functions 
+	vdisk_flush Flush;
+	/* more device specific functions
 	 * needs to be added like eject
 	 */
 }AuVDisk;
@@ -185,6 +195,21 @@ AU_EXTERN AU_EXPORT size_t AuVDiskRead(AuVDisk *disk, uint64_t lba, uint32_t cou
 * @return the amount of data being written in bytes
 */
 AU_EXTERN AU_EXPORT size_t AuVDiskWrite(AuVDisk* disk, uint64_t lba, uint32_t count, uint64_t* buffer);
+
+/**
+* @brief AuVDiskFlush -- flushes a single registered disk's write
+* cache, if its driver provides one (no-op otherwise)
+* @param disk -- Pointer to vdisk structure
+* @return 0 on success/no-op, driver-defined non-zero on failure
+*/
+AU_EXTERN AU_EXPORT int AuVDiskFlush(AuVDisk* disk);
+
+/**
+* @brief AuVDiskFlushAll -- flushes every registered disk's write
+* cache; meant to be called before power-down/reset so no dirty
+* device-side cache is lost
+*/
+AU_EXTERN AU_EXPORT void AuVDiskFlushAll();
 
 /**
  * @brief AuVDiskDestroy -- destroy's a vdisk

--- a/BaseHdr/Mm/pmmngr.h
+++ b/BaseHdr/Mm/pmmngr.h
@@ -39,50 +39,55 @@
 #define AURORA_PAGE_SHM     (1ULL<<1)
 #define AURORA_PAGE_DMA     (1ULL<<2)
 #define AURORA_PAGE_NORMAL (1ULL << 3)
-/**
- * AuPageDesc -- stores metadata
- * about each physical page
- */
+extern void AuPmmngrInitialize(KERNEL_BOOT_INFO *info);
+
+#define PMM_INVALID_PHYS UINT64_MAX
+
+typedef struct _au_pmm_stats_ {
+	uint64_t managed_pages;
+	uint64_t free_pages;
+	uint64_t allocated_pages;
+	uint64_t reserved_pages;
+	uint64_t unmanaged_pages;
+} AuPmmStats;
+
+#ifdef ARCH_ARM64
+AU_EXTERN AU_EXPORT uint64_t AuPmmngrAllocPage(uint8_t page_type);
+AU_EXTERN AU_EXPORT uint64_t AuPmmngrAllocPages(uint32_t pages,
+	uint32_t alignment_pages, uint64_t max_phys_inclusive, uint8_t page_type);
+AU_EXTERN AU_EXPORT bool AuPmmngrReleasePage(uint64_t physaddr);
+AU_EXTERN AU_EXPORT bool AuPmmngrReleasePages(uint64_t physaddr);
+AU_EXTERN AU_EXPORT bool AuPmmngrRetainPage(uint64_t physaddr);
+AU_EXTERN AU_EXPORT uint16_t AuPmmngrPageRefcount(uint64_t physaddr);
+AU_EXTERN AU_EXPORT bool AuPmmngrSetBackingBlock(uint64_t physaddr, int64_t block);
+AU_EXTERN AU_EXPORT int64_t AuPmmngrGetBackingBlock(uint64_t physaddr);
+AU_EXTERN AU_EXPORT void AuPmmngrGetStats(AuPmmStats* stats);
+extern bool AuPmmngrValidate(void);
+#else
 typedef struct _au_page_desc_ {
 	uint64_t phys_addr;
 	uint16_t refcount;
 	uint64_t last_accessed;
 	uint8_t page_type;
 	int64_t diskblock;
-}AuPageDesc;
-
-/**
-* @brief AuPmmngrInitialise -- initialise the physical memory
-* manager
-* @param info -- Pointer to kernel boot info structure
-*/
-extern void AuPmmngrInitialize(KERNEL_BOOT_INFO *info);
-
-/**
- * @brief AuPmmngrAlloc -- Allocate a single physical page
- * frame and return it to the caller
- */
+} AuPageDesc;
 AU_EXTERN AU_EXPORT void* AuPmmngrAlloc();
-
-/**
- * @brief AuPmmngrAllocBlocks -- Allocate multiple physical page frames
- * and return the first page pointer to the caller
- * @param size -- Number of blocks to allocate
- */
 AU_EXTERN AU_EXPORT void* AuPmmngrAllocBlocks(int num);
-
-/**
- * @brief AuPmmngrFree -- Free a physical page frame
- * @param Address -- Pointer to physical page
- */
 AU_EXTERN AU_EXPORT void AuPmmngrFree(void* Address);
-
-/**
- * @brief AuPmmngrFreeBlocks -- Free multiple page frames
- * @param Addr -- Address of the first page frame
- * @param Count -- Number of blocks to be freed
- */
 AU_EXTERN AU_EXPORT void AuPmmngrFreeBlocks(void* Addr, int Count);
+extern uint64_t AuPmmngrGetFreeMem();
+extern uint64_t AuPmmngrGetUsedMem();
+extern uint64_t AuPmmngrGetTotalMem();
+extern void AuPmmngrAddRefcount(uint64_t physaddr, uint16_t count);
+extern uint16_t AuPmmngrGetRefcount(uint64_t physaddr);
+extern AuPageDesc* AuPmmngrGetPageDesc(uint64_t physaddr);
+extern void AuPmmngrSetPageType(uint64_t physaddr, uint8_t flags);
+#define AuPmmngrAllocPage(type) ((uint64_t)AuPmmngrAlloc())
+#define AuPmmngrAllocPages(pages, alignment, ceiling, type) \
+	((uint64_t)AuPmmngrAllocBlocks((int)(pages)))
+#define AuPmmngrReleasePage(physaddr) \
+	(AuPmmngrFree((void*)(uint64_t)(physaddr)), true)
+#endif
 
 /**
  * @brief P2V -- Physical to Virtual conversion
@@ -101,53 +106,4 @@ AU_EXTERN AU_EXPORT uint64_t V2P(uint64_t vaddr);
 * of memory
 */
 extern void AuPmmngrMoveHigher();
-
-/**
- * @brief AuPmmngrGetFreeMem -- returns the total free amount
- * of RAM
- */
-extern uint64_t AuPmmngrGetFreeMem();
-
-/**
- * @brief AuPmmngrGetUsedMem -- return total used page count
- */
-extern uint64_t AuPmmngrGetUsedMem();
-
-/**
- * @brief AuPmmngrGetTotalMem -- returns the total amount of
- * RAM
- */
-extern uint64_t AuPmmngrGetTotalMem();
-
-/**
- * @brief AuPmmngrAddRefcount -- increment reference count
- * of given page
- * @param physaddr -- Physical address to increase reference
- * count of
- * @param count -- number of count to increase
- */
-extern void AuPmmngrAddRefcount(uint64_t physaddr, uint16_t count);
-
-/**
- * @brief AuPmmngrGetRefcount -- returns the number of
- * reference count for given physical address
- * @param physaddr -- physical address to check for reference
- * count
- * @return number of reference count
- */
-extern uint16_t AuPmmngrGetRefcount(uint64_t physaddr);
-
-/**
- * @brief AuPmmngrGetPageDesc -- return the correct
- * page descriptor of given physical address
- * @param physaddr -- physical address number
- */
-extern AuPageDesc* AuPmmngrGetPageDesc(uint64_t physaddr);
-
-/**
- * @brief AuPmmngrSetPageType -- set page type
- * @param physaddr -- Physical address to treat
- * @param flags -- type flags
- */
-extern void AuPmmngrSetPageType(uint64_t physaddr, uint8_t flags);
 #endif

--- a/BaseHdr/Mm/tlsf.h
+++ b/BaseHdr/Mm/tlsf.h
@@ -47,8 +47,7 @@ extern "C" {
 #define SL_INDEX_MASK          (SL_INDEX_COUNT - 1)
 
 /* First-level bitmap: one bit per power-of-two range */
-#define FL_INDEX_MAX           (8 * sizeof(size_t) - SL_INDEX_COUNT_LOG2)  /* 59 on 64-bit */
-#define FL_INDEX_COUNT         (FL_INDEX_MAX + 1)
+#define FL_INDEX_COUNT         (8 * sizeof(size_t))
 
 /* ---- Block header layout ---- */
 /* Block header: 2 × size_t = 16 bytes on 64-bit.
@@ -82,7 +81,7 @@ typedef struct free_block {
 
 /* ---- TLSF pool / control structure ---- */
 typedef struct tlsf_pool {
-    uint32_t  fl_bitmap;
+    uint64_t  fl_bitmap;
     uint32_t  sl_bitmap[FL_INDEX_COUNT];
     free_block_t *blocks[FL_INDEX_COUNT][SL_INDEX_COUNT];
     size_t    pool_size;

--- a/BaseHdr/aurora.h
+++ b/BaseHdr/aurora.h
@@ -131,6 +131,10 @@ typedef struct _KERNEL_BOOT_INFO_ {
 	/* mem_map_size -- UEFI memory map size */
 	uint64_t mem_map_size;
 
+	/* Install the physical direct map here from the loader itself --axiss */
+	uint64_t physical_direct_map_base;
+	uint64_t physical_direct_map_size;
+
 	/* graphics_framebuffer -- framebuffer address passed by XNLDR */
 	uint32_t* graphics_framebuffer;
 

--- a/BootAA64/Makefile
+++ b/BootAA64/Makefile
@@ -84,14 +84,22 @@ $(EFI_OUTPUT): $(OBJS)
 else
 # Original GCC compilation
 $(SO_OUTPUT): $(CRT0) $(OBJS)
-	$(LD) -nostdlib --warn-common --no-undefined --build-id=sha1 -z noexecstack -z max-page-size=4096 \
+	# clib.o and gnu-efi's libefi.a both define memset/memcpy, and that's
+	# always a hard link error, not a -fno-common thing. clib.o links before
+	# the archive so its copy wins; I just needed to tell ld to allow it
+	# instead of aborting on the duplicate --axiss
+	$(LD) -nostdlib --warn-common --no-undefined --allow-multiple-definition --build-id=sha1 -z noexecstack -z max-page-size=4096 \
 	-shared -Bsymbolic $(LIBDIRS) -T$(LDSCRIPT) $(CRT0) $(OBJS) -o $@ $(LIBS)
 
 $(EFI_OUTPUT): $(SO_OUTPUT)
 	@mkdir -p $(dir $@)
+	# used to pass --target=efi-app-aarch64 here but this binutils (2.47)
+	# doesn't ship that BFD target at all, objcopy just said "file format
+	# not recognized". pei-aarch64-little is the real one for aarch64 here
+	# (same target KernelAA64/Makefile already uses) --axiss
 	$(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .rodata -j .rel -j .rela \
 	           -j .rel.* -j .rela.* -j .rel* -j .rela* -j .areloc \
-	           -j .reloc --target=efi-app-aarch64 --subsystem=10 $< $@
+	           -j .reloc -O pei-aarch64-little --subsystem=10 $< $@
 endif
 
 # Compile C++ source files

--- a/BootAA64/paging.cpp
+++ b/BootAA64/paging.cpp
@@ -158,6 +158,30 @@ void XEPagingInitialize() {
 		l0_table_base = (uint64_t*)read_ttbr0_el2();*/
 }
 
+void XEPagingInstallPhysicalDirectMap() {
+	const uint64_t directBase = 0xFFFF800000000000ULL;
+	const uint64_t l0Index = pml4_index(directBase);
+	uint64_t* l1_table = (uint64_t*)XEPmmngrAllocate();
+	if (!l1_table)
+		return;
+	memset(l1_table, 0, PAGESIZE);
+	for (uint64_t i = 0; i < 512; ++i) {
+		uint64_t phys = i << 30;
+		l1_table[i] = phys | PAGE_TABLE_ENTRY_PRESENT | PAGE_TABLE_ENTRY_BLOCK |
+			PAGE_TABLE_ENTRY_AF | PAGE_TABLE_ENTRY_SH | PAGE_TABLE_ENTRY_AP_RW |
+			PAGE_TABLE_ENTRY_MEMATTR | PAGE_TABLE_ENTRY_PXN | PAGE_TABLE_ENTRY_UXN;
+	}
+	l0_table_base[l0Index] = ((uint64_t)l1_table & ~0xFFFULL) |
+		PAGE_TABLE_ENTRY_PRESENT | PAGE_TABLE_ENTRY_PAGE;
+	/* the heap slot is owned by Aurora, make sure it doesnt inherit some
+	 * arbitrary firmware mapping just because its L0 entry has the valid
+	 * bit set --axiss */
+	l0_table_base[pml4_index(0xFFFFE00000000000ULL)] = 0;
+	dsb_ish();
+	tlb_flush_all();
+	isb_flush();
+}
+
 void XEPagingInit2() {
 	uint64_t* l0_table = (uint64_t*)XEPmmngrAllocate();
 	memset(l0_table, 0, 4096);

--- a/BootAA64/paging.h
+++ b/BootAA64/paging.h
@@ -41,8 +41,8 @@
 #define PAGE_TABLE_ENTRY_SH_NONE (0UL << 8)
 #define PAGE_TABLE_ENTRY_AP_RW	 (0UL << 6)
 #define PAGE_TABLE_ENTRY_MEMATTR (1UL << 2)
-#define PAGE_TABLE_ENTRY_PXN	 (1UL << 53)
-#define PAGE_TABLE_ENTRY_UXN	 (1UL << 54)
+#define PAGE_TABLE_ENTRY_PXN	 (1ULL << 53)
+#define PAGE_TABLE_ENTRY_UXN	 (1ULL << 54)
 #define PAGE_TABLE_ENTRY_DEVICE	 (0ULL << 2)
 
 #define PAGE_FLAGS                                                                                 \
@@ -60,6 +60,7 @@ extern void XEPagingInitialize();
  * @param physAddr -- physical address
  */
 extern void XEPagingMap(uint64_t virtualAddr, uint64_t physAddr);
+extern void XEPagingInstallPhysicalDirectMap();
 
 /* Checks if a virtual page is already mapped to prevent overwriting during PE section overlapping */
 extern bool XEPagingIsMapped(uint64_t virtualAddr);

--- a/BootAA64/physm.cpp
+++ b/BootAA64/physm.cpp
@@ -58,7 +58,8 @@ void XEInitialisePmmngr(const struct EfiMemoryMap memmap, void* buffer, size_t b
 	bufsize /= 2;
 	_bufsz = bufsize;
 	allocatedPtr = allocatedStack = raw_offset<paddr_t*>(buffer, bufsize);
-	allocatedCount = 1;
+	/* I keep allocatedPtr one-past-the-last allocated page, just in case --axiss */
+	allocatedCount = 0;
 
 	EFI_MEMORY_DESCRIPTOR* current = memmap.memmap;
 	while (raw_diff(current, memmap.memmap) < memmap.MemMapSize) {
@@ -99,7 +100,7 @@ paddr_t XEPmmngrAllocate() {
 		paddr_t allocated = *--stackptr;
 		if (raw_diff(allocatedPtr, allocatedStack) < _bufsz) {
 			*allocatedPtr++ = allocated;
-			allocatedCount++;
+			++allocatedCount;
 		} else {
 			XEGuiPrint("xnldr warning: allocatedStack full, no longer tracking allocationg \r\n");
 		}

--- a/BootAA64/xnldr.cpp
+++ b/BootAA64/xnldr.cpp
@@ -36,6 +36,7 @@
 #include "video.h"
 #include "file.h"
 #include "xnout.h"
+
 #include "pe.h"
 #include "physm.h"
 #include "paging.h"
@@ -590,6 +591,7 @@ extern "C" EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemT
 	for (int i = 0; i <= 0x100000 / PAGESIZE; i++) {
 		XEPagingMap(0xFFFFA00000000000 + i * PAGESIZE, XEPmmngrAllocate());
 	}
+	XEPagingInstallPhysicalDirectMap();
 
 	/*
 	 * Changes are made according to RPI_EFI
@@ -598,11 +600,13 @@ extern "C" EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemT
 	 * to drop to EL1 before entering Kernel
 	 */
 	bootinfo.boot_type = BOOT_UEFI_ARM64;
-	bootinfo.allocated_mem = XEGetAlstackptr();
+	bootinfo.allocated_stack = XEGetAlstackptr();
 	bootinfo.reserved_mem_count = XEReserveMemCount();
 	bootinfo.map = map.memmap;
 	bootinfo.descriptor_size = map.DescriptorSize;
 	bootinfo.mem_map_size = map.MemMapSize;
+	bootinfo.physical_direct_map_base = 0xFFFF800000000000ULL;
+	bootinfo.physical_direct_map_size = 512ULL << 30;
 	bootinfo.graphics_framebuffer = XEGetFramebuffer();
 	bootinfo.X_Resolution = XEGetScreenWidth();
 	bootinfo.Y_Resolution = XEGetScreenHeight();
@@ -615,14 +619,14 @@ extern "C" EFI_STATUS efi_main(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE* SystemT
 	bootinfo.acpi_table_pointer = xdsp_address;
 	bootinfo.kernel_size = krnl->FileSize;
 	bootinfo.printf_gui = XEGuiPrint;
-	bootinfo.font_binary_address = 0;
+	bootinfo.psf_font_data = 0;
 	bootinfo.driver_entry1 = (uint8_t*)initrd->kBuffer;
 	bootinfo.driver_entry2 = 0;
 	bootinfo.driver_entry3 = 0; // (uint8_t*)xhciAddr;// usbAddr;
 	bootinfo.driver_entry4 = 0;
 	bootinfo.driver_entry5 = 0;
 	bootinfo.driver_entry6 = 0;
-	bootinfo.ap_code = fdt_address;
+	bootinfo.apcode = fdt_address;
 	bootinfo.hid = initrd->FileSize;
 	bootinfo.uid = 0;
 	bootinfo.cid = 0;

--- a/BootAA64/xnldr.h
+++ b/BootAA64/xnldr.h
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <Uefi.h>
 #include <stddef.h>
+#include <aurora.h>
 #ifndef SIZE_MAX
 #if defined(ARCH_ARM64) || defined(ARCH_X64) || defined(_M_AMD64) || defined(_M_ARM64) ||          \
 	defined(__x86_64__) || defined(__aarch64__)
@@ -71,44 +72,9 @@ typedef struct _FB_INFO_ {
 	uint32_t resvmask;
 } FRAMEBUFFER_INFORMATION, *PFRAMEBUFFER_INFORMATION;
 
-#define BOOT_UEFI_X64	1
-#define BOOT_UEFI_ARM64 2
-/* XEBootInfo, Xeneva Boot information
- * structure passed to the kernel
- */
-typedef struct _XE_BOOT_INFO_ {
-	int boot_type;
-	void* allocated_mem;
-	uint64_t reserved_mem_count;
-	void* map;
-	uint64_t descriptor_size;
-	uint64_t mem_map_size;
-	uint32_t* graphics_framebuffer;
-	size_t fb_size;
-	uint16_t X_Resolution;
-	uint16_t Y_Resolution;
-	uint16_t pixels_per_line;
-	uint32_t redmask;
-	uint32_t greenmask;
-	uint32_t bluemask;
-	uint32_t resvmask;
-	void* acpi_table_pointer;
-	size_t kernel_size;
-	uint8_t* font_binary_address;
-	void (*printf_gui)(const char* text, ...);
-	uint8_t* driver_entry1; //!OTHER
-	uint8_t* driver_entry2; //!NVME
-	uint8_t* driver_entry3; //!AHCI
-	uint8_t* driver_entry4; //!FLOPPY
-	uint8_t* driver_entry5; //!ATA
-	uint8_t* driver_entry6; //!USB
-	void* ap_code;
-
-	/*Boot device specific */
-	uint32_t hid;
-	uint32_t uid;
-	uint32_t cid;
-} XEBootInfo, *XEPBootInfo;
+/* I intentionally have the loader and kernel share one hand-off structure, better not fragment it --axiss */
+typedef KERNEL_BOOT_INFO XEBootInfo;
+typedef KERNEL_BOOT_INFO* XEPBootInfo;
 
 //#pragma pack(pop)
 

--- a/Docs/BuildInstructions(ARM64).md
+++ b/Docs/BuildInstructions(ARM64).md
@@ -16,6 +16,7 @@ Once the installation is completed, the Clang directory needs to be added to Win
 
 ## ImDisk as disk imager
 The XenevaOS bootloader expects a ramdisk image to be present inside the boot partition. The boot partition is a regular FAT32 partition that UEFI expects. The ramdisk image __"initrd2.img"__ contains all the system files that XenevaOS needs to boot smoothly. The image should be formatted with the FAT32 filesystem with a size of at least 358 MB and an allocation unit of 4 KiB. <br><br>
+*Note: 358 MB is a safe fixed size for manually creating the image by hand (e.g. with ImDisk, below). `Scripts/Linux/build_and_run_qemu.sh` no longer uses a fixed size — it sizes `initrd2.img` automatically from the actual contents of `Resources/resources/` (with headroom), since that tree is currently much smaller than 358 MB. Use `--initrd-size-mb=N` to override it.*<br><br>
 To create a blank image file, follow here:
 
 - Create a blank batch file, copy the following code, and run it in the Command Prompt:

--- a/Docs/BuildInstructions(Linux).md
+++ b/Docs/BuildInstructions(Linux).md
@@ -36,7 +36,7 @@ To automate the creation of the FAT32 boot image and launch the OS in QEMU, use 
 3. Run the script:
    `./Scripts/Linux/build_and_run_qemu.sh`
 
-*Note: The GCC build for ARM64 automatically defines `__TARGET_BOARD_QEMU_VIRT__`, which tells the bootloader to bypass the interactive screen resolution menu. This allows QEMU to boot directly into the OS without hanging for user input.*
+*Note: Both the GCC and LLVM/Clang ARM64 builds define `__TARGET_BOARD_QEMU_VIRT__` by default (`BOARD ?= qemu_virt` in `BootAA64/Makefile` and `KernelAA64/Makefile`, independent of toolchain). This controls which ramdisk filename the bootloader loads (`initrd2.img` vs `initrd.img`), UART port selection, and whether a second paging-init pass runs — it does **not** skip the interactive screen-resolution menu (`XEGetScreenResolutionMode` in `BootAA64/xnldr.cpp` runs unconditionally). That menu currently only accepts input from the emulated USB/virtio keyboard, so QEMU always needs one keypress (Enter) to proceed past it; there is no confirmed way to automate this non-interactively yet (`Scripts/Linux/build_and_run_qemu.sh --headless` only bounds the wait with a timeout instead of hanging forever).*
 
 ### Building `initrd2.img` Manually
 If you do not have a pre-built `initrd2.img` or want to generate a fresh one from the `Resources/resources/` directory, you can pass a flag to force a manual build:

--- a/Drivers/AHCI/disk.cpp
+++ b/Drivers/AHCI/disk.cpp
@@ -289,11 +289,11 @@ size_t AHCIDiskWrite(AuVFSNode* _node_, AuVFSNode* file, uint64_t* buffer, uint3
     uint64_t lba = file->pos / 512;
 	uint64_t lba_bytes = static_cast<uint64_t>(len) * 512;
 	AuVDisk* disk = (AuVDisk*)file->device;
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 	memcpy(buff, buffer, lba_bytes);
 	AuAHCIVDiskWrite(disk, lba, len,(uint64_t*)V2P((size_t)buff));
-	AuPmmngrFree((void*)V2P((size_t)buff));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 	return lba_bytes;
 }
 
@@ -309,12 +309,12 @@ size_t AHCIDiskRead(AuVFSNode* _node_, AuVFSNode* file, uint64_t* buffer, uint32
 	uint64_t lba = file->pos / 512;
 	uint64_t lba_bytes = static_cast<uint64_t>(len) * 512;
 	AuVDisk* disk = (AuVDisk*)file->device;
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 	AuAHCIVDiskRead(disk, lba, len, (uint64_t*)V2P((size_t)buff));
 	memcpy(buffer,buff, lba_bytes);
 	
-	AuPmmngrFree((void*)V2P((size_t)buff));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 	return lba_bytes;
 }
 
@@ -331,7 +331,7 @@ void AHCIDiskInitialise(AHCIController *controller,HBA_PORT* port) {
 	uint64_t phys;
 
 	/* Allocate command list */
-	phys = (uint64_t)AuPmmngrAlloc();
+	phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	port->clb = phys & 0xffffffff;
 	port->clbu = phys >> 32;
 
@@ -339,7 +339,7 @@ void AHCIDiskInitialise(AHCIController *controller,HBA_PORT* port) {
 	memset((void*)phys, 0, 4096);
 
 	/* Allocate FIS */
-	phys = (uint64_t)AuPmmngrAlloc();
+	phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	port->fb = phys & 0xffffffff;
 	port->fbu = (phys >> 32);
 
@@ -353,7 +353,7 @@ void AHCIDiskInitialise(AHCIController *controller,HBA_PORT* port) {
 
 	for (int i = 0; i < 31; i++) {
 		cmd_list[i].prdtl = 1;
-		phys = (uint64_t)AuPmmngrAlloc();
+		phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		cmd_list[i].ctba = phys & 0xffffffff;
 		cmd_list[i].ctbau = phys >> 32;
 		cmd_list[i].p = 1;
@@ -376,7 +376,7 @@ void AHCIDiskInitialise(AHCIController *controller,HBA_PORT* port) {
 
 	uint8_t current_slot = port->cmd & (1 << 8);
 
-	uint64_t* addr = (uint64_t*)AuPmmngrAlloc();
+	uint64_t* addr = (uint64_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset(addr, 0, 4096);
 	AuAHCIDiskIdentify(port, 0, 1, addr);
 	char ata_device_name[40];
@@ -433,5 +433,5 @@ void AHCIDiskInitialise(AHCIController *controller,HBA_PORT* port) {
 	AuDevFSAddFile(controller->devfs, controller->controllerpath, file);
 	controller->CurrentPortID++;
 
-	AuPmmngrFree((void*)addr);
+	AuPmmngrReleasePage((uint64_t)addr);
 }

--- a/Drivers/E1000/e1000.cpp
+++ b/Drivers/E1000/e1000.cpp
@@ -421,22 +421,22 @@ AU_EXTERN AU_EXPORT int AuDriverMain() {
 		nic_thread_required = true;
 	}
 
-	e1000_nic->rx_phys = (uint64_t)P2V((size_t)AuPmmngrAlloc());
+	e1000_nic->rx_phys = (uint64_t)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	e1000_nic->rx = (e1000_rx_desc*)e1000_nic->rx_phys;
-	e1000_nic->tx_phys = (uint64_t)P2V((size_t)AuPmmngrAlloc());
+	e1000_nic->tx_phys = (uint64_t)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	e1000_nic->tx = (e1000_tx_desc*)e1000_nic->tx_phys;
 
 	memset(e1000_nic->rx, 0, sizeof(e1000_rx_desc)* 512);
 	memset(e1000_nic->tx, 0, sizeof(e1000_tx_desc)* 512);
 
 	for (int i = 0; i < 512; i++) {
-		e1000_nic->rx[i].addr = (uint64_t)AuPmmngrAlloc();
+		e1000_nic->rx[i].addr = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		e1000_nic->rx_virt[i] = (uint8_t*)AuMapMMIO(e1000_nic->rx[i].addr, 1);
 		e1000_nic->rx[i].status = 0;
 	}
 
 	for (int i = 0; i < E1000_NUM_TX_DESC; ++i) {
-		e1000_nic->tx[i].addr = (uint64_t)AuPmmngrAlloc();
+		e1000_nic->tx[i].addr = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		e1000_nic->tx_virt[i] = (uint8_t*)AuMapMMIO(e1000_nic->tx[i].addr, 1);
 		memset(e1000_nic->tx_virt[i], 0, PAGE_SIZE);
 		e1000_nic->tx[i].status = 0;
@@ -523,7 +523,7 @@ AU_EXTERN AU_EXPORT int AuDriverMain() {
 	}
 	else {
 		AuTextOut("[E1000]: No MSI/MSI-X supported, Spawning e1000 worker thread \n");
-		AuThread* nic_thr = AuCreateKthread(E1000Thread, (uint64_t)P2V((size_t)AuPmmngrAlloc() + PAGE_SIZE),
+		AuThread* nic_thr = AuCreateKthread(E1000Thread, (uint64_t)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL) + PAGE_SIZE),
 			(uint64_t)AuGetRootPageTable(), "E1000Thr");
 	}
 

--- a/Drivers/GPU/virtiogpu/virtgpu.cpp
+++ b/Drivers/GPU/virtiogpu/virtgpu.cpp
@@ -199,7 +199,7 @@ void gpu_initialize_controlq(VirtioCommonCfg* cfg) {
 
 	int queueSz = cfg->QueueSize;
 	controlq_sz = queueSz;
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	controlq = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 	UARTDebugOut("[virtio-gpu]: controlq size : %d \r\n", queueSz);
 	cfg->QueueDesc = queuePhys;
@@ -225,7 +225,7 @@ void gpu_initialize_cursorq(VirtioCommonCfg* cfg) {
 	int queueSz = cfg->QueueSize;
 	UARTDebugOut("[virtio-gpu]: cursorq size : %d \r\n", queueSz);
 	cursorq_sz = queueSz;
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	cursorq = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 	UARTDebugOut("[virtio-gpu]: controlq size : %d \r\n", queueSz);
 	cfg->QueueDesc = queuePhys;
@@ -454,7 +454,7 @@ AU_EXTERN AU_EXPORT int AuDriverMain() {
 	_is_virgl_supported = false;
 	_resp_ok = false;
 	gpu_resource_id = 1;
-	command_phys = (void*)P2V((uint64_t)AuPmmngrAlloc());
+	command_phys = (void*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	resp_phys = (void*)((uint64_t)command_phys + 2048);
 	memset(command_phys, 0, PAGE_SIZE);
 

--- a/Drivers/GPU/virtiogpu/virtscreen.cpp
+++ b/Drivers/GPU/virtiogpu/virtscreen.cpp
@@ -82,7 +82,7 @@ void virt_gpu_alloc_fb(VirtioCommonCfg* cfg, int resource_id) {
 	size_t fb_sz = (len + PAGE_SIZE - 1) / PAGE_SIZE;
 	uint64_t fb_phys = 0;
 	for (int i = 0; i < fb_sz; i++) {
-		uint64_t phys = (uint64_t)AuPmmngrAlloc();
+		uint64_t phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		AuMapPage(phys, GPU_FB_BUFFER + i * PAGE_SIZE, PTE_NORMAL_NON_CACHEABLE);
 		if (fb_phys == 0)
 			fb_phys = phys;

--- a/Drivers/NVMe/namespace.cpp
+++ b/Drivers/NVMe/namespace.cpp
@@ -208,7 +208,7 @@ void NVMeInitialiseNamespace(NVMeDev* nvme, NVMeControllerIdentity* controller, 
 		namespace_->maxBlocks = ni->namespaceSize;
 		namespace_->totalSizeInMiB = diskSizeInMiB;
 		namespace_->blockSize = blockSize;
-		namespace_->physDataBuffer = (uint64_t)AuPmmngrAlloc();
+		namespace_->physDataBuffer = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		namespace_->physMMIOBuffer = (uint64_t)AuMapMMIO(namespace_->physDataBuffer, 1);
 		memset((void*)namespace_->physMMIOBuffer, 0, PAGE_SIZE);
 

--- a/Drivers/NVMe/nvme.cpp
+++ b/Drivers/NVMe/nvme.cpp
@@ -305,8 +305,8 @@ void NVMeAllocateQueues(uint16_t num) {
 
 NVMeQueue* NVMeCreateIOQueue(){
 	NVMeQueue* queue = NULL;
-	uint64_t sqPhysBase = (uint64_t)AuPmmngrAlloc();
-	uint64_t cqPhysBase = (uint64_t)AuPmmngrAlloc();
+	uint64_t sqPhysBase = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+	uint64_t cqPhysBase = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 
 	uint16_t queueID = nvme->queueAllocatedID;
 
@@ -330,8 +330,8 @@ NVMeQueue* NVMeCreateIOQueue(){
 
 	if (completion.status > 0) {
 		SeTextOut("[NVMe]: Creating I/O comp QUEUE status %d %x\r\n", completion.status, completion.status);
-		AuPmmngrFree((void*)cqPhysBase);
-		AuPmmngrFree((void*)sqPhysBase);
+		AuPmmngrReleasePage((uint64_t)cqPhysBase);
+		AuPmmngrReleasePage((uint64_t)sqPhysBase);
 		kfree(queue);
 		return NULL;
 		
@@ -356,7 +356,7 @@ NVMeQueue* NVMeCreateIOQueue(){
 	NVMeSubmitCommand(Admin, &command, &completion);
 
 	if (completion.status > 0){
-		AuPmmngrFree((void*)sqPhysBase);
+		AuPmmngrReleasePage((uint64_t)sqPhysBase);
 		SeTextOut("[NVMe]: I/O Sq creation failed %d \r\n", completion.status);
 		kfree(queue);
 		return NULL;
@@ -381,7 +381,7 @@ NVMeQueue* NVMeCreateIOQueue(){
  * NVMeIdentifyController -- identify controller command
  */
 void NVMeIdentifyController() {
-	uint64_t* controlphys = (uint64_t*)AuPmmngrAlloc();
+	uint64_t* controlphys = (uint64_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset(controlphys, 0, PAGE_SIZE);
 
 	NVMeCommand iden;
@@ -408,7 +408,7 @@ void NVMeIdentifyController() {
 	}
 	
 	for (unsigned i = 0; i < ci->numNamespaces; i++) {
-		uint64_t* physAddr = (uint64_t*)AuPmmngrAlloc();
+		uint64_t* physAddr = (uint64_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		memset(physAddr, 0, PAGE_SIZE);
 		
 		NVMeCommand identifyNS;
@@ -422,16 +422,16 @@ void NVMeIdentifyController() {
 		NVMeSubmitCommand(admin, &identifyNS, &comp);
 		
 		if (comp.status > 0) {
-			AuPmmngrFree((void*)physAddr);
+			AuPmmngrReleasePage((uint64_t)physAddr);
 			continue;
 		}
 		NamespaceIdentity *ni = (NamespaceIdentity*)physAddr;
 		NVMeInitialiseNamespace(nvme,ci, ni, i + 1);
 
-		AuPmmngrFree((void*)physAddr);
+		AuPmmngrReleasePage((uint64_t)physAddr);
 	}
 
-	AuPmmngrFree((void*)controlphys);
+	AuPmmngrReleasePage((uint64_t)controlphys);
 }
 /*
 * NVMeInitialise -- start nvme storage class
@@ -502,9 +502,9 @@ int NVMeInitialise() {
 	config |= NVME_CFG_DEFAULT_IOCQES | NVME_CFG_DEFAULT_IOSQES;
 	NVMeOutl(NVME_REGISTER_CC, config);
 
-	uint64_t adminSQ = (uint64_t)AuPmmngrAlloc();
+	uint64_t adminSQ = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)adminSQ, 0, PAGE_SIZE);
-	uint64_t adminCQ = (uint64_t)AuPmmngrAlloc();
+	uint64_t adminCQ = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)adminCQ, 0, PAGE_SIZE);
 
 	uint64_t adminSQMMIOBase = (uint64_t)AuMapMMIO(adminSQ, 1);

--- a/Drivers/Net/virtionet/virtionet.cpp
+++ b/Drivers/Net/virtionet/virtionet.cpp
@@ -208,7 +208,7 @@ void AuVirtioNetRxinitialize(struct VirtioCommonCfg* common) {
 	isb_flush();
 	dsb_ish();
 
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	rxqueue = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 
 	common->QueueDesc = queuePhys;
@@ -220,7 +220,7 @@ void AuVirtioNetRxinitialize(struct VirtioCommonCfg* common) {
 	dsb_ish();
 
 
-	uint64_t rxbuff = (uint64_t)AuPmmngrAllocBlocks(4);
+	uint64_t rxbuff = AuPmmngrAllocPages(4, 1, 0, AURORA_PAGE_DMA);
 	rx_hdrs = (virtio_net_hdr_t*)AuMapMMIO(rxbuff, 4);
 	for (int i = 0; i < RX_BUFFER_COUNT; i++) {
 		rxqueue->buffers[i].Addr = rxbuff + (i * 2048);
@@ -254,7 +254,7 @@ void AuVirtioNetTxinitialize(struct VirtioCommonCfg* common) {
 	common->QueueSize = TX_BUFFER_COUNT;
 	isb_flush();
 	dsb_ish();
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	txqueue = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 	common->QueueDesc = queuePhys;
 	common->QueueAvail = (queuePhys)+OFFSETOF(struct VirtioQueue, available);
@@ -266,7 +266,7 @@ void AuVirtioNetTxinitialize(struct VirtioCommonCfg* common) {
 	isb_flush();
 	dsb_ish();
 
-	uint64_t txbuff = (uint64_t)AuPmmngrAllocBlocks(4);
+	uint64_t txbuff = AuPmmngrAllocPages(4, 1, 0, AURORA_PAGE_DMA);
 	for (int i = 0; i < TX_BUFFER_COUNT; i++) {
 		txqueue->buffers[i].Addr = txbuff + (i * 2048);
 		txqueue->buffers[i].Length = TX_BUFFER_SIZE;

--- a/Drivers/Sound/IntelHDA/ihda.cpp
+++ b/Drivers/Sound/IntelHDA/ihda.cpp
@@ -443,8 +443,8 @@ AU_EXTERN AU_EXPORT int AuDriverMain() {
 
 	uintptr_t mmio = AuPCIERead(device, PCI_BAR0, bus, dev, func);
 	_hdaudio->mmio = (uint64_t)AuMapMMIO(mmio, 1);
-	_hdaudio->corb = (uint32_t*)P2V((size_t)AuPmmngrAlloc());
-	_hdaudio->rirb = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	_hdaudio->corb = (uint32_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
+	_hdaudio->rirb = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)_hdaudio->corb, 0, PAGE_SIZE);
 	memset((void*)_hdaudio->rirb, 0, PAGE_SIZE);
 

--- a/Drivers/Sound/IntelHDA/stream.cpp
+++ b/Drivers/Sound/IntelHDA/stream.cpp
@@ -39,7 +39,7 @@ int HDAInitOutput() {
 	uint64_t phys_buf = 0;
 	strm_buf = (uint64_t*)pos;
 	for (int i = 0; i < (BDL_SIZE*BUFFER_SIZE / PAGE_SIZE); i++) {
-		void*p = AuPmmngrAlloc();
+		void* p = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (phys_buf == 0)
 			phys_buf = (uint64_t)p;
 		AuMapPage((size_t)p, pos + static_cast<uint64_t>(i) * 4096, X86_64_PAGING_NO_CACHING | X86_64_PAGING_NO_EXECUTE |
@@ -65,7 +65,7 @@ int HDAInitOutput() {
 
 	_aud_outb_(REG_O0_STS, HDAC_SDSTS_DESE | HDAC_SDSTS_FIFOE | HDAC_SDSTS_BCIS);
 
-	uint64_t bdl_base = (uint64_t)AuPmmngrAlloc();   //get_physical_address  ((uint64_t) 0x0000000000000000);
+	uint64_t bdl_base = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);   //get_physical_address  ((uint64_t) 0x0000000000000000);
 	HDABDLEntry *bdl = (HDABDLEntry*)bdl_base;  //(_ihd_audio.corb + 3072);
 
 	int j = 0;
@@ -91,7 +91,7 @@ int HDAInitOutput() {
 	_aud_outw_(REG_O0_FMT, format);
 
 
-	uint64_t* dma_pos = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* dma_pos = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(dma_pos, 0, 4096);
 
 	//_ihd_audio.dma_pos = dma_pos;
@@ -120,7 +120,7 @@ int HDAInitInputStream() {
 	uint64_t phys_buf = 0;
 	
 	for (int i = 0; i < (4 * BUFFER_SIZE / 4096); i++) {
-		void *p = AuPmmngrAlloc();
+		void* p = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (phys_buf == 0)
 			phys_buf = (uint64_t)p;
 		AuMapPage((uint64_t)p, pos + static_cast<uint64_t>(i) * 4096, (1 << 4));
@@ -142,7 +142,7 @@ int HDAInitInputStream() {
 
 	_aud_outb_(REG_I0_STS, HDAC_SDSTS_DESE | HDAC_SDSTS_FIFOE | HDAC_SDSTS_BCIS);
 
-	uint64_t bdl_base = (uint64_t)AuPmmngrAlloc();   //get_physical_address  ((uint64_t) 0x0000000000000000);
+	uint64_t bdl_base = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);   //get_physical_address  ((uint64_t) 0x0000000000000000);
 	HDABDLEntry *bdl = (HDABDLEntry*)bdl_base;  //(_ihd_audio.corb + 3072);
 
 	int j = 0;
@@ -166,7 +166,7 @@ int HDAInitInputStream() {
 
 
 
-	uint64_t* dma_pos = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* dma_pos = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(dma_pos, 0, 4096);
 
 	//_ihd_audio.dma_pos = dma_pos;

--- a/Drivers/Sound/virtiosnd/main.cpp
+++ b/Drivers/Sound/virtiosnd/main.cpp
@@ -285,7 +285,7 @@ static void virtio_snd_alloc_controlq(VirtioCommonCfg* cfg) {
 
 	int queueSz = cfg->QueueSize;
 	controlq_sz = queueSz;
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	controlq = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 #if DEBUG
 	UARTDebugOut("[virtio-snd]: controlq size : %d \r\n", queueSz);
@@ -319,7 +319,7 @@ static void virtio_snd_alloc_eventq(struct VirtioCommonCfg* cfg) {
 
 	int queueSz = cfg->QueueSize;
 	eventq_sz = queueSz;
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	eventq = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 
 #if DEBUG
@@ -352,7 +352,7 @@ static void virtio_snd_alloc_txq(VirtioCommonCfg* cfg) {
 
 	int queueSz = cfg->QueueSize;
 	txq_sz = queueSz;
-	uint64_t queuePhys = (uint64_t)AuPmmngrAlloc();//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+	uint64_t queuePhys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	txq = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 #if DEBUG
 	UARTDebugOut("[virtio-snd]: txq size : %d \r\n", queueSz);
@@ -852,7 +852,7 @@ AU_EXTERN AU_EXPORT int AuDriverMain(AuDriver* drv) {
 	_output_running = false;
 	_input_running = false;
 
-	command_phys = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	command_phys = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	resp_phys = (void*)((uint64_t)command_phys + 2048);
 	memset(command_phys, 0, PAGE_SIZE);
 	controlq_lst_idx = 0;
@@ -860,7 +860,7 @@ AU_EXTERN AU_EXPORT int AuDriverMain(AuDriver* drv) {
 	txq_lst_idx = 0;
 	_force_hardware = false;
 
-	pcm_buffer = (void*)P2V((uint64_t)AuPmmngrAlloc());
+	pcm_buffer = (void*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(pcm_buffer, 0, 0x1000);
 
 	/** change the class/subclass value **/

--- a/Drivers/USB/dwc2-otg/dwc2_channel.cpp
+++ b/Drivers/USB/dwc2-otg/dwc2_channel.cpp
@@ -359,7 +359,7 @@ bool dwc2_control_transfer(struct dwc2_core_regs* regs, dwc2_usb_endpoint_t* ep,
 	uint16_t wValue, uint16_t wIndex, void* data, uint16_t wLength) {
 
 	uint64_t setup_phys = 0;
-	usb_setup_packet_t* setup = (usb_setup_packet_t*)AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_setup_packet_t), &setup_phys); //P2V((uint64_t)AuPmmngrAlloc());
+	usb_setup_packet_t* setup = (usb_setup_packet_t*)AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_setup_packet_t), &setup_phys); //P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	//aa64_data_cache_clean_range(setup, 4096);
 	setup->bmRequestType = bmRequestType;
 	setup->bmRequest = b_request;
@@ -467,7 +467,7 @@ bool dwc2_control_transfer(struct dwc2_core_regs* regs, dwc2_usb_endpoint_t* ep,
 	}
 
 	AuDMAGClassFree(dwc2_get_dma_class(), setup, setup_phys, sizeof(usb_setup_packet_t));
-	//AuPmmngrFree((void*)V2P((uint64_t)setup));
+	//AuPmmngrReleasePage((uint64_t)V2P((uint64_t)setup));
 
 	return 0;
 	/** free up the channel **/

--- a/Drivers/USB/dwc2-otg/dwc2_root.cpp
+++ b/Drivers/USB/dwc2-otg/dwc2_root.cpp
@@ -93,7 +93,7 @@ void dwc2_enumerate_root_device(struct dwc2_core_regs* regs) {
 	//ep.speed = speed;
 	//ep.max_packet_sz = 8;
 
-	//void* desc = (void*)AuPmmngrAlloc();
+	//void* desc = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	//memset(desc, 0, 4096);
 	//UARTDebugOut("Desc addr : %x \r\n", desc);
 	//dwc2_control_transfer(regs, &ep, 0x80, 0x06, 0x0100, 0, desc, 0x0008);
@@ -146,7 +146,7 @@ void dwc2_enumerate_root_device(struct dwc2_core_regs* regs) {
 	//}
 	//
 
-	//void* desc2 = (void*)AuPmmngrAlloc();
+	//void* desc2 = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	//memset(desc2, 0, 4096);
 	//dwc2_control_transfer(regs, &ep, 0xA0, 0x06, 0x2900, 0, desc2, 8);
 	//usb_hub_desc_t* hub = (usb_hub_desc_t*)desc2;
@@ -161,7 +161,7 @@ void dwc2_enumerate_root_device(struct dwc2_core_regs* regs) {
 	//UARTDebugOut("Port powered up \r\n");
 
 	//return;
-	//void* desc3 = (void*)AuPmmngrAlloc();
+	//void* desc3 = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	//memset(desc3, 0, 4096);
 
 	//for (int i = 1; i <= hub->bNbrPorts; i++) {
@@ -186,14 +186,14 @@ void dwc2_enumerate_root_device(struct dwc2_core_regs* regs) {
 	//intep.speed = ep.speed;
 	//intep.type = USB_EP_TYPE_INTERRUPT;
 
-	//void* inbuf = AuPmmngrAlloc();
+	//void* inbuf = AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	//memset(inbuf, 0, 4096);
 	//intb = inbuf;
 	//dwc2_interrupt_transfer(regs, &intep, inbuf, 0, 0, USB_PID_DATA0);
 
-	//AuPmmngrFree(desc3);
-	//AuPmmngrFree(desc2);
-	//AuPmmngrFree(desc);
+	//AuPmmngrReleasePage(desc3);
+	//AuPmmngrReleasePage(desc2);
+	//AuPmmngrReleasePage(desc);
 	//dwc2_free_used_dma_list();
 
 	_all_init = true;
@@ -224,7 +224,7 @@ void* root_hub_get_interrupt_buffer() {
 #define PORT_CHANGE_RESET (1<<4)
 
 void root_hub_handle_port_change(dwc2_core_regs* regs, uint8_t port) {
-	void* p = AuPmmngrAlloc();
+	void* p = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	usb_hub_get_port_status(regs, port, p, 1, speed_);
 	AA64SleepMS(10);
 

--- a/Drivers/USB/dwc2-otg/dwc2_usbdev.cpp
+++ b/Drivers/USB/dwc2-otg/dwc2_usbdev.cpp
@@ -65,7 +65,7 @@ static bool dwc2_usbdev_configure(dwc2_core_regs* regs, dwc2_usb_device* dev) {
 
 	uint64_t config_desc_phys = 0;
 
-	void* desc = AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_config_desc_t), &config_desc_phys);//(void*)P2V((uint64_t)AuPmmngrAlloc());
+	void* desc = AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_config_desc_t), &config_desc_phys);//(void*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 
 	if (dwc2_control_transfer(regs, &dev->ep, 0x80, 0x06, 0x0200, 0x0000, (void*)config_desc_phys, 9)) {
 		UARTDebugOut("[dwc2-otg]: failed to get configuration descriptor \r\n");
@@ -184,7 +184,7 @@ bool dwc2_usbdev_initialize(dwc2_core_regs* regs, uint8_t port, uint8_t hub_addr
 
 	uint64_t dev_desc_phys = 0;
 	/** get the first device descriptor **/
-	void* desc = (void*)AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_dev_desc_t), &dev_desc_phys);   //P2V((uint64_t)AuPmmngrAlloc());
+	void* desc = (void*)AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_dev_desc_t), &dev_desc_phys);   //P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(desc, 0, 4096);
 	if (dwc2_control_transfer(regs, &usb->ep, 0x80, 0x06, 0x0100, 0, (void*)dev_desc_phys, 0x0008)) {
 		UARTDebugOut("[dwc2_otg]: failed to device descriptor \r\n");
@@ -198,7 +198,7 @@ bool dwc2_usbdev_initialize(dwc2_core_regs* regs, uint8_t port, uint8_t hub_addr
 
 	if (dwc2_usbdev_setaddress(regs, usb, address)) {
 		kfree(usb);
-		AuPmmngrFree((void*)V2P((uint64_t)desc));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)desc));
 		return 1;
 	}
 
@@ -233,12 +233,12 @@ bool dwc2_usbdev_initialize(dwc2_core_regs* regs, uint8_t port, uint8_t hub_addr
 	dwc2_usb_get_string(regs, usb, desc_->iManufacturer, lang_id, product);
 	UARTDebugOut("manufactured by : %s \r\n", product);
 
-	//AuPmmngrFree(strdesc);
+	//AuPmmngrReleasePage(strdesc);
 
 	if (dwc2_usbdev_configure(regs, usb)) {
 		kfree(usb);
 		UARTDebugOut("[dwc2-otg]: failed to configure the device \r\n");
-		//AuPmmngrFree((void*)V2P((uint64_t)desc));
+		//AuPmmngrReleasePage((uint64_t)V2P((uint64_t)desc));
 		return 1;
 	}
 	return 0;

--- a/Drivers/USB/dwc2-otg/lan7800.cpp
+++ b/Drivers/USB/dwc2-otg/lan7800.cpp
@@ -113,7 +113,7 @@ void lan7800_read_mac_from_eeprom(dwc2_core_regs* regs, dwc2_usb_device* dev, ui
  */
 void lan7800_initialize(dwc2_core_regs* regs, dwc2_usb_device* dev) {
 	uint32_t timeout = 100;
-	dev->scratchBuff = AuPmmngrAlloc();
+	dev->scratchBuff = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	while (timeout--) {
 		uint32_t hw_cfg = lan7800_read_reg(regs, dev, 0x010);
 		if (hw_cfg & 0x2) break;

--- a/Drivers/USB/dwc2-otg/main.cpp
+++ b/Drivers/USB/dwc2-otg/main.cpp
@@ -651,7 +651,7 @@ void dwc2_add_to_used_dma_list(void* phys) {
 void dwc2_free_used_dma_list() {
 	for (int i = 0; i < setupPacketBuffers->pointer; i++) {
 		void* phys = (void*)list_remove(setupPacketBuffers, i);
-		AuPmmngrFree((void*)V2P((uint64_t)phys));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)phys));
 	}
 }
 

--- a/Drivers/USB/dwc2-otg/usb_stdhub.cpp
+++ b/Drivers/USB/dwc2-otg/usb_stdhub.cpp
@@ -48,7 +48,7 @@ bool usb_hub_initialize(dwc2_core_regs* regs, dwc2_usb_device* dev) {
 	UARTDebugOut("usb hub initializing.... \r\n");
 
 	uint64_t hub_phys_out = 0;
-	void* hub = (void*)AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_hub_desc_t), &hub_phys_out); //P2V((uint64_t)AuPmmngrAlloc());
+	void* hub = (void*)AuDMAGClassAlloc(dwc2_get_dma_class(), sizeof(usb_hub_desc_t), &hub_phys_out); //P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	//memset(hub, 0, 4096);
 	if (dwc2_control_transfer(regs, &dev->ep, 0xA0, 0x06, 0x2900, 0, (void*)hub_phys_out/*V2P((uint64_t)hub)*/, 8)) {
 		UARTDebugOut("failed to get hub descriptor \r\n");
@@ -71,7 +71,7 @@ bool usb_hub_initialize(dwc2_core_regs* regs, dwc2_usb_device* dev) {
 	
 	
 	uint64_t status_phys = 0;
-	void* scratchBuff = (void*)AuDMAGClassAlloc(dwc2_get_dma_class(), 8, &status_phys);//AuPmmngrAlloc();
+	void* scratchBuff = (void*)AuDMAGClassAlloc(dwc2_get_dma_class(), 8, &status_phys);//AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	
 	// Time to RESET all ports yaayyy
 	int numPorts = desc->bNbrPorts;

--- a/Drivers/USB/dwc2-uspi/dwhcidevice.c
+++ b/Drivers/USB/dwc2-uspi/dwhcidevice.c
@@ -228,7 +228,7 @@ int DWHCIDeviceControlMessage (TDWHCIDevice *pThis, TUSBEndpoint *pEndpoint,
 {
 	assert (pThis != 0);
 
-	TSetupData* SetupData = (TSetupData*)AuPmmngrAlloc();	// DMA buffer
+	TSetupData* SetupData = (TSetupData*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);	// DMA buffer
 
 	SetupData->bmRequestType = ucRequestType;
 	SetupData->bRequest      = ucRequest;
@@ -246,7 +246,7 @@ int DWHCIDeviceControlMessage (TDWHCIDevice *pThis, TUSBEndpoint *pEndpoint,
 		nResult = USBRequestGetResultLength (&URB);
 	}
 	
-	AuPmmngrFree(SetupData);
+	AuPmmngrReleasePage((uint64_t)SetupData);
 	_USBRequest (&URB);
 
 	return nResult;

--- a/Drivers/USB/dwc2-uspi/lan7800.c
+++ b/Drivers/USB/dwc2-uspi/lan7800.c
@@ -351,7 +351,7 @@ boolean LAN7800DeviceConfigure (TUSBFunction *pUSBFunction)
 
 	// check chip ID
 
-	u32* nValue = (uint32_t*)AuPmmngrAlloc();
+	u32* nValue = (uint32_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	if (   !LAN7800DeviceReadReg (pThis, ID_REV, nValue)
 	    || (*nValue & ID_REV_CHIP_ID_MASK) >> 16 != ID_REV_CHIP_ID_7800)
 	{

--- a/Drivers/USB/dwc2-uspi/usbdevice.c
+++ b/Drivers/USB/dwc2-uspi/usbdevice.c
@@ -100,14 +100,14 @@ void _USBDevice (TUSBDevice *pThis)
 	if (pThis->m_pConfigDesc != 0)
 	{
 		//free (pThis->m_pConfigDesc);
-		AuPmmngrFree(pThis->m_pConfigDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pConfigDesc);
 		pThis->m_pConfigDesc = 0;
 	}
 
 	if (pThis->m_pDeviceDesc != 0)
 	{
 		//free (pThis->m_pDeviceDesc);
-		AuPmmngrFree(pThis->m_pDeviceDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pDeviceDesc);
 		pThis->m_pDeviceDesc = 0;
 	}
 
@@ -129,7 +129,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 	assert (pThis != 0);
 
 	assert (pThis->m_pDeviceDesc == 0);
-	pThis->m_pDeviceDesc = (TUSBDeviceDescriptor*)AuPmmngrAlloc(); // malloc(sizeof(TUSBDeviceDescriptor));
+	pThis->m_pDeviceDesc = (TUSBDeviceDescriptor*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL); // malloc(sizeof(TUSBDeviceDescriptor));
 	assert (pThis->m_pDeviceDesc != 0);
 
 	assert (pThis->m_pHost != 0);
@@ -144,7 +144,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 		USBDeviceLogWrite (pThis, LOG_ERROR, "Cannot get device descriptor (short)");
 
 		//free (pThis->m_pDeviceDesc);
-		AuPmmngrFree(pThis->m_pDeviceDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pDeviceDesc);
 		pThis->m_pDeviceDesc = 0;
 
 		return FALSE;
@@ -171,7 +171,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 		USBDeviceLogWrite (pThis, LOG_ERROR, "Cannot get device descriptor");
 
 		//free (pThis->m_pDeviceDesc);
-		AuPmmngrFree(pThis->m_pDeviceDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pDeviceDesc);
 		pThis->m_pDeviceDesc = 0;
 
 		return FALSE;
@@ -218,7 +218,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 	}
 
 	assert (pThis->m_pConfigDesc == 0);
-	pThis->m_pConfigDesc = (TUSBConfigurationDescriptor*)AuPmmngrAlloc(); // malloc(sizeof(TUSBConfigurationDescriptor));
+	pThis->m_pConfigDesc = (TUSBConfigurationDescriptor*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL); // malloc(sizeof(TUSBConfigurationDescriptor));
 	assert (pThis->m_pConfigDesc != 0);
 
 	if (DWHCIDeviceGetDescriptor (pThis->m_pHost, pThis->m_pEndpoint0,
@@ -229,7 +229,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 		USBDeviceLogWrite (pThis, LOG_ERROR, "Cannot get configuration descriptor (short)");
 
 		//free (pThis->m_pConfigDesc);
-		AuPmmngrFree(pThis->m_pConfigDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pConfigDesc);
 		pThis->m_pConfigDesc = 0;
 
 		return FALSE;
@@ -243,7 +243,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 		USBDeviceLogWrite (pThis, LOG_ERROR, "Invalid configuration descriptor");
 		
 		//free (pThis->m_pConfigDesc);
-		AuPmmngrFree(pThis->m_pConfigDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pConfigDesc);
 		pThis->m_pConfigDesc = 0;
 
 		return FALSE;
@@ -254,7 +254,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 	//free(pThis->m_pConfigDesc);
 	AuPmmngrFree (pThis->m_pConfigDesc);
 
-	pThis->m_pConfigDesc = (TUSBConfigurationDescriptor*)AuPmmngrAlloc();// malloc (nTotalLength);
+	pThis->m_pConfigDesc = (TUSBConfigurationDescriptor*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);// malloc (nTotalLength);
 	assert (pThis->m_pConfigDesc != 0);
 
 	if (DWHCIDeviceGetDescriptor (pThis->m_pHost, pThis->m_pEndpoint0,
@@ -265,7 +265,7 @@ boolean USBDeviceInitialize (TUSBDevice *pThis)
 		USBDeviceLogWrite (pThis, LOG_ERROR, "Cannot get configuration descriptor");
 
 		//free (pThis->m_pConfigDesc);
-		AuPmmngrFree(pThis->m_pConfigDesc);
+		AuPmmngrReleasePage((uint64_t)pThis->m_pConfigDesc);
 		pThis->m_pConfigDesc = 0;
 
 		return FALSE;

--- a/Drivers/USB/dwc2-uspi/usbstandardhub.c
+++ b/Drivers/USB/dwc2-uspi/usbstandardhub.c
@@ -112,7 +112,7 @@ boolean USBStandardHubConfigure (TUSBFunction *pUSBFunction)
 	assert (pHost != 0);
 
 	assert (pThis->m_pHubDesc == 0);
-	pThis->m_pHubDesc = (TUSBHubDescriptor*)AuPmmngrAlloc(); // malloc(sizeof(TUSBHubDescriptor));
+	pThis->m_pHubDesc = (TUSBHubDescriptor*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL); // malloc(sizeof(TUSBHubDescriptor));
 	assert (pThis->m_pHubDesc != 0);
 
 	if (DWHCIDeviceGetDescriptor (pHost, USBFunctionGetEndpoint0 (&pThis->m_USBFunction),
@@ -188,7 +188,7 @@ boolean USBStandardHubEnumeratePorts (TUSBStandardHub *pThis)
 	for (unsigned nPort = 0; nPort < pThis->m_nPorts; nPort++)
 	{
 		assert (pThis->m_pStatus[nPort] == 0);
-		pThis->m_pStatus[nPort] = AuPmmngrAlloc();// malloc (sizeof (TUSBPortStatus));
+		pThis->m_pStatus[nPort] = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);// malloc (sizeof (TUSBPortStatus));
 		assert (pThis->m_pStatus[nPort] != 0);
 
 		if (DWHCIDeviceControlMessage (pHost, pEndpoint0,

--- a/Drivers/USB/hid/main.cpp
+++ b/Drivers/USB/hid/main.cpp
@@ -529,7 +529,7 @@ AU_EXTERN AU_EXPORT int AuUSBDriverMain(AuUSBDeviceStruc* dev) {
 	}
 
 
-	uint64_t buff = (uint64_t)AuPmmngrAlloc();
+	uint64_t buff = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)buff, 0, PAGE_SIZE);
 	uint8_t* report = (uint8_t*)buff;
 
@@ -544,7 +544,7 @@ AU_EXTERN AU_EXPORT int AuUSBDriverMain(AuUSBDeviceStruc* dev) {
 	t_idx = -1;
 	t_idx = dev->AuUSBWait(dev, USB_WAIT_EVENT_TRANSFER);
 
-	mouse_data = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	mouse_data = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)mouse_data, 0, PAGE_SIZE);
 
 	void* ep = dev->AuGetEndpoint(dev, ENDPOINT_TRANSFER_TYPE_INT);

--- a/Drivers/USB/msc/main.cpp
+++ b/Drivers/USB/msc/main.cpp
@@ -152,7 +152,7 @@ void AuUSBMSCSendCommand(AuUSBDeviceStruc *dev, void* bulkIn, void* bulkOut, SCS
 		dev->AuBulkTranfer(dev, (uint64_t)resp, respSize, bulkIn);
 		dev->AuUSBWait(dev, USB_WAIT_EVENT_TRANSFER);
 	}
-	SCSIStatus* csw = (SCSIStatus*)P2V((uint64_t)AuPmmngrAlloc());
+	SCSIStatus* csw = (SCSIStatus*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(csw, 0, sizeof(SCSIStatus));
 	dev->AuBulkTranfer(dev, V2P((uint64_t)csw), sizeof(SCSIStatus), bulkIn);
 	dev->AuUSBWait(dev, USB_WAIT_EVENT_TRANSFER);
@@ -160,7 +160,7 @@ void AuUSBMSCSendCommand(AuUSBDeviceStruc *dev, void* bulkIn, void* bulkOut, SCS
 	if (csw->signature == SCSI_CMD_STATUS_SIGNATURE) {
 		SeTextOut("USB MSC -- Command submitted successfully \r\n");
 	}
-	AuPmmngrFree((void*)V2P((uint64_t)csw));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)csw));
 }
 
 uint32_t convEndian(uint32_t value) {
@@ -186,7 +186,7 @@ uint32_t cpuBe32(uint32_t value) {
  * @param buffer -- Buffer address where to store the data
  */
 void AuUSBMSCRead(AuUSBDeviceStruc* dev, uint32_t lba, uint16_t numBlocks, uint32_t blockSz, uint64_t* buffer) {
-	SCSICommand* cbw = (SCSICommand*)P2V((uint64_t)AuPmmngrAlloc());
+	SCSICommand* cbw = (SCSICommand*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(cbw, 0, 4096);
 	cbw->signature = SCSI_CMD_BLK_SIGNATURE;
 	cbw->tag = 0x12345678;
@@ -203,7 +203,7 @@ void AuUSBMSCRead(AuUSBDeviceStruc* dev, uint32_t lba, uint16_t numBlocks, uint3
 
 	AuUSBMSCSendCommand(dev, bulkIn, bulkOut, (SCSICommand*)V2P((uint64_t)cbw), buffer, numBlocks * blockSz);
 
-	AuPmmngrFree((void*)V2P((uint64_t)cbw));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)cbw));
 
 }
 
@@ -216,7 +216,7 @@ void AuUSBMSCRead(AuUSBDeviceStruc* dev, uint32_t lba, uint16_t numBlocks, uint3
  * @param buffer -- buffer to write
  */
 void AuUSBMSCWrite(AuUSBDeviceStruc* dev, uint32_t lba, uint16_t numBlocks, uint32_t blockSz, uint64_t* buffer) {
-	SCSICommand* cbw = (SCSICommand*)P2V((uint64_t)AuPmmngrAlloc());
+	SCSICommand* cbw = (SCSICommand*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(cbw, 0, 4096);
 	cbw->signature = SCSI_CMD_BLK_SIGNATURE;
 	cbw->tag = 0x12345678;
@@ -240,7 +240,7 @@ void AuUSBMSCWrite(AuUSBDeviceStruc* dev, uint32_t lba, uint16_t numBlocks, uint
 	dev->AuUSBWait(dev, USB_WAIT_EVENT_TRANSFER);
 
 	/* read the status from bulkIn */
-	SCSIStatus* csw = (SCSIStatus*)P2V((uint64_t)AuPmmngrAlloc());
+	SCSIStatus* csw = (SCSIStatus*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(csw, 0, sizeof(SCSIStatus));
 	dev->AuBulkTranfer(dev, V2P((uint64_t)csw), sizeof(SCSIStatus), bulkIn);
 	dev->AuUSBWait(dev, USB_WAIT_EVENT_TRANSFER);
@@ -249,8 +249,8 @@ void AuUSBMSCWrite(AuUSBDeviceStruc* dev, uint32_t lba, uint16_t numBlocks, uint
 		SeTextOut("USB MSC -- write successfull \r\n");
 	};
 
-	AuPmmngrFree((void*)V2P((uint64_t)cbw));
-	AuPmmngrFree((void*)V2P((uint64_t)csw));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)cbw));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)csw));
 
 }
 
@@ -358,8 +358,8 @@ AU_EXTERN AU_EXPORT int AuUSBDriverMain(AuUSBDeviceStruc* dev) {
 	int t_idx = -1;
 	t_idx = dev->AuUSBWait(dev, USB_WAIT_EVENT_TRANSFER);
 
-	SCSICommand* cbw = (SCSICommand*)P2V((uint64_t)AuPmmngrAlloc());
-	SCSIInquiryResponse* resp = (SCSIInquiryResponse*)P2V((uint64_t)AuPmmngrAlloc());
+	SCSICommand* cbw = (SCSICommand*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
+	SCSIInquiryResponse* resp = (SCSIInquiryResponse*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(resp, 0, sizeof(SCSIInquiryResponse));
 	memset(cbw, 0, sizeof(SCSICommand));
 
@@ -447,8 +447,8 @@ AU_EXTERN AU_EXPORT int AuUSBDriverMain(AuUSBDeviceStruc* dev) {
 	AuVDiskRegister(disk);
 
 
-	AuPmmngrFree((void*)V2P((uint64_t)resp));
-	AuPmmngrFree((void*)V2P((uint64_t)cbw));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)resp));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)cbw));
 	AuTextOut("USB MSC driver initialised %d \n", t_idx);
 
 	return 0;

--- a/Drivers/Usb3/classes/hid.cpp
+++ b/Drivers/Usb3/classes/hid.cpp
@@ -544,7 +544,7 @@ void USBHidInitialise(USBDevice* dev, XHCISlot* slot, uint8_t classC, uint8_t su
 		ep_->callback = HIDCallback;
 
 
-	uint64_t buff = (uint64_t)AuPmmngrAlloc();
+	uint64_t buff = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)buff, 0, PAGE_SIZE);
 	uint8_t* report = (uint8_t*)buff;
 
@@ -560,10 +560,10 @@ void USBHidInitialise(USBDevice* dev, XHCISlot* slot, uint8_t classC, uint8_t su
 	t_idx = XHCIPollEvent(dev, TRB_EVENT_TRANSFER);
 
 
-	mouse_data = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	mouse_data = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)mouse_data, 0, ep_->max_packet_sz);
 
 	XHCISendNormalTRB(dev, slot, V2P(mouse_data), ep_->max_packet_sz,ep_);
 	
-	AuPmmngrFree((void*)buff);
+	AuPmmngrReleasePage((uint64_t)buff);
 }

--- a/Drivers/Usb3/classes/hub.cpp
+++ b/Drivers/Usb3/classes/hub.cpp
@@ -36,7 +36,7 @@
 #include <_null.h>
 
 void HUBSetPortFeature(USBDevice* dev, XHCISlot* slot, uint8_t feature, uint8_t port) {
-	uint64_t buf = (uint64_t)P2V((size_t)AuPmmngrAlloc());
+	uint64_t buf = (uint64_t)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)buf, 0, 4096);
 
 	USB_REQUEST_PACKET pack;
@@ -62,7 +62,7 @@ void HUBGetDescriptor(USBDevice* dev, XHCISlot* slot, uint64_t buffer, uint16_t 
 
 
 void USBHubInitialise(USBDevice* dev, XHCISlot* slot) {
-	uint64_t buffer = (uint64_t)P2V((size_t)AuPmmngrAlloc());
+	uint64_t buffer = (uint64_t)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)buffer, 0, PAGE_SIZE);
 
 	uint8_t hub_def_numports = 4;

--- a/Drivers/Usb3/main.cpp
+++ b/Drivers/Usb3/main.cpp
@@ -310,7 +310,7 @@ AU_EXTERN AU_EXPORT int AuDriverMain() {
 	* Here, initialize the USB thread, which is responsible for
 	* many hotplugging things
 	*/
-	AuThread *t = AuCreateKthread(AnuvabUSB3Thread, P2V((uint64_t)AuPmmngrAlloc() + 4096), (uint64_t)AuGetRootPageTable(), "AnubhavUsb");
+	AuThread *t = AuCreateKthread(AnuvabUSB3Thread, P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL) + 4096), (uint64_t)AuGetRootPageTable(), "AnubhavUsb");
 	usb_device->usb_thread = t;
 	usb_device->initialised = true;
 	AuDisableInterrupt();

--- a/Drivers/Usb3/usb3.cpp
+++ b/Drivers/Usb3/usb3.cpp
@@ -82,7 +82,7 @@ void XHCIReset(USBDevice *dev) {
  * structure
  */
 void XHCIDeviceContextInit(USBDevice *dev) {
-	uint64_t phys = (uint64_t)AuPmmngrAlloc();
+	uint64_t phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)phys, 0, PAGE_SIZE);
 	uint64_t* dcbaa = (uint64_t*)AuMapMMIO(phys, 1);
 	dev->dev_ctx_base_array = dcbaa;
@@ -93,11 +93,11 @@ void XHCIDeviceContextInit(USBDevice *dev) {
 	uint32_t max_scratchpad = (scratch_hi << 5) | scratch_lo;
 
 	if (max_scratchpad) {
-		uint64_t *spad = (uint64_t*)AuPmmngrAlloc();
+		uint64_t *spad = (uint64_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		memset(spad, 0, PAGE_SIZE);
 
 		for (unsigned i = 0; i < max_scratchpad; i++) {
-			spad[i] = (uint64_t)AuPmmngrAlloc();
+			spad[i] = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 			memset(&spad[i], 0, PAGE_SIZE);
 		}
 	}
@@ -109,7 +109,7 @@ void XHCIDeviceContextInit(USBDevice *dev) {
  * @param dev -- Pointer to usb device
  */
 void XHCICommandRingInit(USBDevice *dev) {
-	uint64_t cmd_ring_phys = (uint64_t)AuPmmngrAlloc();
+	uint64_t cmd_ring_phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)cmd_ring_phys, 0, PAGE_SIZE);
 	dev->cmd_ring = (xhci_trb_t*)AuMapMMIO(cmd_ring_phys, 1);
 
@@ -233,11 +233,11 @@ XHCISlot* XHCICreateDeviceCtx(USBDevice* dev, uint8_t slot_num, uint8_t port_spe
 	slot->endpoints = initialize_list();
 
 
-	uint64_t output_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t output_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	uint64_t* output_ctx_ptr = (uint64_t*)output_ctx;
 	memset((void*)output_ctx, 0, PAGE_SIZE);
 
-	uint64_t input_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t input_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	uint8_t *input_ctx_ptr = (uint8_t*)input_ctx;
 	memset((void*)input_ctx, 0, 4096);
 
@@ -252,7 +252,7 @@ XHCISlot* XHCICreateDeviceCtx(USBDevice* dev, uint8_t slot_num, uint8_t port_spe
 	*raw_offset<volatile uint32_t*>(input_ctx, 0x40) = USB_ENDPOINT_CTX_DWORD0(0, 0, 0, 0, 0, 0);
 	*raw_offset<volatile uint32_t*>(input_ctx, 0x40 + 4) = USB_ENDPOINT_CTX_DWORD1(XHCIGetMaxPacketSize(port_speed), 0, 0, 4, 3);
 
-	uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)cmd_ring, 0, 4096);
 
 	uint64_t* cmd_ring_virt = (uint64_t*)AuMapMMIO(V2P(cmd_ring), 1);
@@ -341,11 +341,11 @@ void XHCIProtocolInit(USBDevice *dev) {
 * @param dev -- Pointer to usb device
 */
 void XHCIEventRingInit(USBDevice *dev) {
-	uint64_t e_ring_seg_table = (uint64_t)AuPmmngrAlloc();
+	uint64_t e_ring_seg_table = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	uint64_t* event_ring_seg_table_v = (uint64_t*)AuMapMMIO(e_ring_seg_table, 1);
 	memset(event_ring_seg_table_v, 0, PAGE_SIZE);
 
-	uint64_t event_ring_seg = (uint64_t)AuPmmngrAlloc();
+	uint64_t event_ring_seg = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	uint64_t* event_ring_seg_v = (uint64_t*)AuMapMMIO(event_ring_seg, 1);
 	memset(event_ring_seg_v, 0, PAGE_SIZE);
 	dev->event_ring_segment = event_ring_seg_v;
@@ -612,9 +612,9 @@ void XHCIPortInitialize(USBDevice *dev, unsigned int port) {
 
 		dev->dev_ctx_base_array[slot_id] = 0;
 
-		AuPmmngrFree((void*)slot->input_context_phys);
-		AuPmmngrFree((void*)slot->output_context_phys);
-		AuPmmngrFree((void*)slot->cmd_ring_base);
+		AuPmmngrReleasePage((uint64_t)slot->input_context_phys);
+		AuPmmngrReleasePage((uint64_t)slot->output_context_phys);
+		AuPmmngrReleasePage((uint64_t)slot->cmd_ring_base);
 
 		XHCISlotRemove(dev, slot_id);
 
@@ -654,7 +654,7 @@ void XHCIPortInitialize(USBDevice *dev, unsigned int port) {
 
 		slot->port_speed = port_speed;
 
-		uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+		uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset(buffer, 0, 4096);
 
 		USBGetDeviceDesc(dev, slot, slot_id, V2P((uint64_t)buffer), 18);
@@ -695,7 +695,7 @@ void XHCIPortInitialize(USBDevice *dev, unsigned int port) {
 		/* Now we have fully operational endpoint 0 pipe */
 
 		/* Get the product (device) name using string descriptor */
-		uint64_t* string_buf = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+		uint64_t* string_buf = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset(string_buf, 0, PAGE_SIZE);
 
 		USBGetStringDesc(dev,slot,slot_id,V2P((uint64_t)string_buf),dev_desc->iProduct);
@@ -820,7 +820,7 @@ void XHCIPortInitialize(USBDevice *dev, unsigned int port) {
 			auto max_esit = max_packet_sz * (max_burst_sz + 1);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0) = USB_ENDPOINT_CTX_DWORD0(max_esit >> 16, interval, 0, 0, 0, 0);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0x04) = USB_ENDPOINT_CTX_DWORD1(max_packet_sz, max_burst_sz, 1, ep_type, cerr);
-			uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+			uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 			memset((void*)cmd_ring, 0, 4096);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0x08) = USB_ENDPOINT_CTX_DWORD2(V2P(cmd_ring), 1);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0x0C) = USB_ENDPOINT_CTX_DWORD3(V2P(cmd_ring));
@@ -893,8 +893,8 @@ void XHCIPortInitialize(USBDevice *dev, unsigned int port) {
 		* usb keyboard, mice and flash drive
 		*/
 
-		AuPmmngrFree((void*)V2P((size_t)string_buf));
-		//AuPmmngrFree((void*)V2P((size_t)buffer));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)string_buf));
+		//AuPmmngrReleasePage((uint64_t)V2P((size_t)buffer));
 		AuReleaseSpinlock(dev->usb_lock);
 	}
 }

--- a/Drivers/virtioblk/virtioblk.cpp
+++ b/Drivers/virtioblk/virtioblk.cpp
@@ -212,7 +212,7 @@ void virtioblk_alloc_requestQ(VirtioCommonCfg* cfg) {
 	int queueSz = cfg->QueueSize;
 	requestQ_sz = queueSz;
 	UARTDebugOut("[virtio-blk]: requestQ_sz : %d  - sizeof(VirtioQueue) -> %d \r\n", requestQ_sz, sizeof(VirtioQueue));
-	uint64_t queuePhys = (uint64_t)AuPmmngrAllocBlocks(2);//AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+	uint64_t queuePhys = AuPmmngrAllocPages(2, 1, 0, AURORA_PAGE_DMA);
 	requestQ = (struct VirtioBLKQueue*)AuMapMMIO(queuePhys, 2);
 
 	cfg->QueueDesc = queuePhys;

--- a/Drivers/xHCI/main.cpp
+++ b/Drivers/xHCI/main.cpp
@@ -114,7 +114,7 @@ void XHCIReset(XHCIDevice* dev) {
  * structure
  */
 void XHCIDeviceContextInit(XHCIDevice* dev) {
-	uint64_t phys = (uint64_t)AuPmmngrAlloc();
+	uint64_t phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)phys, 0, PAGE_SIZE);
 	uint64_t* dcbaa = (uint64_t*)AuMapMMIO(phys, 1);
 	dev->dev_ctx_base_array = dcbaa;
@@ -125,11 +125,11 @@ void XHCIDeviceContextInit(XHCIDevice* dev) {
 	uint32_t max_scratchpad = (scratch_hi << 5) | scratch_lo;
 
 	if (max_scratchpad) {
-		uint64_t* spad = (uint64_t*)AuPmmngrAlloc();
+		uint64_t* spad = (uint64_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		memset(spad, 0, PAGE_SIZE);
 
 		for (unsigned i = 0; i < max_scratchpad; i++) {
-			spad[i] = (uint64_t)AuPmmngrAlloc();
+			spad[i] = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 			memset(&spad[i], 0, PAGE_SIZE);
 		}
 	}
@@ -142,7 +142,7 @@ void XHCIDeviceContextInit(XHCIDevice* dev) {
  * @param dev -- Pointer to usb device
  */
 void XHCICommandRingInit(XHCIDevice* dev) {
-	uint64_t cmd_ring_phys = (uint64_t)AuPmmngrAlloc();
+	uint64_t cmd_ring_phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)cmd_ring_phys, 0, PAGE_SIZE);
 	dev->cmd_ring = (xhci_trb_t*)AuMapMMIO(cmd_ring_phys, 1);
 
@@ -168,11 +168,11 @@ void XHCICommandRingInit(XHCIDevice* dev) {
 * @param dev -- Pointer to usb device
 */
 void XHCIEventRingInit(XHCIDevice* dev) {
-	uint64_t e_ring_seg_table = (uint64_t)AuPmmngrAlloc();
+	uint64_t e_ring_seg_table = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	uint64_t* event_ring_seg_table_v = (uint64_t*)AuMapMMIO(e_ring_seg_table, 1);
 	memset(event_ring_seg_table_v, 0, PAGE_SIZE);
 
-	uint64_t event_ring_seg = (uint64_t)AuPmmngrAlloc();
+	uint64_t event_ring_seg = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	uint64_t* event_ring_seg_v = (uint64_t*)AuMapMMIO(event_ring_seg, 1);
 	memset(event_ring_seg_v, 0, PAGE_SIZE);
 	dev->event_ring_segment = event_ring_seg_v;
@@ -538,7 +538,7 @@ AU_EXTERN AU_EXPORT int AuDriverMain() {
 	
 	XHCIStartDefaultPorts(xhcidev);
 
-	AuThread* t = AuCreateKthread(AnuvabUSB3Thread, P2V((uint64_t)AuPmmngrAlloc() + 4096), (uint64_t)AuGetRootPageTable(), "AnubhavUsb");
+	AuThread* t = AuCreateKthread(AnuvabUSB3Thread, P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL) + 4096), (uint64_t)AuGetRootPageTable(), "AnubhavUsb");
 	xhcidev->usbThread = t;
 
 	/* Disable all interrupts again because

--- a/Drivers/xHCI/port.cpp
+++ b/Drivers/xHCI/port.cpp
@@ -77,11 +77,11 @@ XHCISlot* XHCICreateDeviceCtx(XHCIDevice* dev, uint8_t slot_num, uint8_t port_sp
 	slot->endpoints = initialize_list();
 
 
-	uint64_t output_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t output_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	uint64_t* output_ctx_ptr = (uint64_t*)output_ctx;
 	memset((void*)output_ctx, 0, PAGE_SIZE);
 
-	uint64_t input_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t input_ctx = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	uint8_t* input_ctx_ptr = (uint8_t*)input_ctx;
 	memset((void*)input_ctx, 0, 4096);
 
@@ -96,7 +96,7 @@ XHCISlot* XHCICreateDeviceCtx(XHCIDevice* dev, uint8_t slot_num, uint8_t port_sp
 	*raw_offset<volatile uint32_t*>(input_ctx, 0x40) = USB_ENDPOINT_CTX_DWORD0(0, 0, 0, 0, 0, 0);
 	*raw_offset<volatile uint32_t*>(input_ctx, 0x40 + 4) = USB_ENDPOINT_CTX_DWORD1(XHCIGetMaxPacketSize(port_speed), 0, 0, 4, 3);
 
-	uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset((void*)cmd_ring, 0, 4096);
 
 	uint64_t* cmd_ring_virt = (uint64_t*)AuMapMMIO(V2P(cmd_ring), 1);
@@ -156,7 +156,7 @@ void XHCISlotReleaseEndpoints(XHCISlot* slot) {
 	for (int i = 0; i < slot->endpoints->pointer; i++) {
 		XHCIEndpoint* ep = (XHCIEndpoint*)list_remove(slot->endpoints, i);
 		if (ep) {
-			AuPmmngrFree((void*)V2P((uint64_t)slot->cmd_ring));
+			AuPmmngrReleasePage((uint64_t)V2P((uint64_t)slot->cmd_ring));
 			kfree(ep);
 		}
 	}
@@ -308,9 +308,9 @@ void XHCIPortInitialise(XHCIDevice* dev, unsigned int port) {
 
 		dev->dev_ctx_base_array[slot_id] = 0;
 
-		AuPmmngrFree((void*)slot->input_context_phys);
-		AuPmmngrFree((void*)slot->output_context_phys);
-		AuPmmngrFree((void*)V2P(slot->cmd_ring_base));
+		AuPmmngrReleasePage((uint64_t)slot->input_context_phys);
+		AuPmmngrReleasePage((uint64_t)slot->output_context_phys);
+		AuPmmngrReleasePage((uint64_t)V2P(slot->cmd_ring_base));
 		
 
 		/* remove endpoint data structures from the slot */
@@ -377,7 +377,7 @@ void XHCIPortInitialise(XHCIDevice* dev, unsigned int port) {
 
 		slot->port_speed = port_speed;
 
-		uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+		uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset(buffer, 0, 4096);
 
 		AuUSBDevice* usbdev = USBCreateDevice();
@@ -425,7 +425,7 @@ void XHCIPortInitialise(XHCIDevice* dev, unsigned int port) {
 		/* Now we have fully operational endpoint 0 pipe */
 
 		/* Get the product (device) name using string descriptor */
-		uint64_t* string_buf = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+		uint64_t* string_buf = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset(string_buf, 0, PAGE_SIZE);
 
 		USBGetStringDesc(usbdev,  V2P((uint64_t)string_buf), dev_desc->iProduct);
@@ -556,7 +556,7 @@ void XHCIPortInitialise(XHCIDevice* dev, unsigned int port) {
 			auto max_esit = max_packet_sz * (max_burst_sz + 1);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0) = USB_ENDPOINT_CTX_DWORD0(max_esit >> 16, interval, 0, 0, 0, 0);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0x04) = USB_ENDPOINT_CTX_DWORD1(max_packet_sz, max_burst_sz, 1, ep_type, cerr);
-			uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+			uint64_t cmd_ring = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 			memset((void*)cmd_ring, 0, 4096);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0x08) = USB_ENDPOINT_CTX_DWORD2(V2P(cmd_ring), 1);
 			*raw_offset<volatile uint32_t*>(input_ctx_virt, addr + 0x0C) = USB_ENDPOINT_CTX_DWORD3(V2P(cmd_ring));

--- a/KernelAA64/Board/Rpi3bp/rpi3bp.c
+++ b/KernelAA64/Board/Rpi3bp/rpi3bp.c
@@ -261,7 +261,7 @@ void AuRPI3ICInit() {
  */
 void AuRPI3Initialize() {
 	vcmbox_mmio = (uint64_t)AuMapMMIO(VIDEOCORE_MBOX, 1);
-	uint64_t pa = (uint64_t)AuPmmngrAlloc();
+	uint64_t pa = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	pa = (pa + 0xFULL) & ~0xFULL;
 	mbox = (uint32_t*)pa;
 	AuTextOut("[aurora]: Rasperry Pi 3b+ board initialized \r\n");

--- a/KernelAA64/Board/Rpi3bp/vc4dsi.c
+++ b/KernelAA64/Board/Rpi3bp/vc4dsi.c
@@ -602,7 +602,7 @@ typedef struct {
 static vc4_fb_t fb;
 
 bool vc4InitDisplay(uint32_t width, uint32_t height, uint32_t depth, display_type_t display_type) {
-	uint64_t pa = (uint64_t)AuPmmngrAlloc();
+	uint64_t pa = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	pa = (pa + 0xFULL) & ~0xFULL;
 	mailBOX = (uint32_t*)pa;
 	memset(mailBOX, 0, 4096);

--- a/KernelAA64/Drivers/virtiokbd.c
+++ b/KernelAA64/Drivers/virtiokbd.c
@@ -201,7 +201,7 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	UARTDebugOut("virtio: queue sz : %d \n", queueSz);
 
 	uint64_t queuePhys = (uint64_t)
-		AuPmmngrAlloc(); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz))/0x1000);
+		AuPmmngrAllocPage(AURORA_PAGE_NORMAL); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz))/0x1000);
 	queue = (struct VirtioQueue*)AuMapMMIO(queuePhys,
 										   1 /*((sizeof(struct VirtioQueue)*queueSz))/0x1000*/);
 
@@ -215,7 +215,7 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	isb_flush();
 	dsb_ish();
 
-	uint64_t bufferBase = (uint64_t)AuPmmngrAlloc();
+	uint64_t bufferBase = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	input = (struct VirtioInputEvent*)AuMapMMIO(bufferBase, 1);
 
 	for (int i = 0; i < queueSz; ++i) {

--- a/KernelAA64/Drivers/virtionet.c
+++ b/KernelAA64/Drivers/virtionet.c
@@ -155,7 +155,7 @@ void AuVirtioNetRxinitialize(struct VirtioCommonCfg* common) {
 	uint16_t qsize = common->QueueSize;
 	UARTDebugOut("[aurora]: rx queue size : %d \r\n", qsize);
 	uint64_t queuePhys = (uint64_t)
-		AuPmmngrAlloc(); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+		AuPmmngrAllocPage(AURORA_PAGE_NORMAL); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	rxqueue = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 
 	common->QueueDesc = queuePhys;
@@ -167,7 +167,12 @@ void AuVirtioNetRxinitialize(struct VirtioCommonCfg* common) {
 	isb_flush();
 	dsb_ish();
 
-	uint64_t rxbuff = (uint64_t)AuPmmngrAllocBlocks(4);
+	/* I address this as one 16 KiB physical run since the device descriptors expect that --axiss */
+	uint64_t rxbuff = (uint64_t)AuPmmngrAllocPages(4, 1, 0, AURORA_PAGE_DMA);
+	if (!rxbuff) {
+		UARTDebugOut("[aurora]: unable to allocate contiguous virtio RX buffer\r\n");
+		return;
+	}
 	for (int i = 0; i < RX_BUFFER_COUNT; i++) {
 		rxqueue->buffers[i].Addr = rxbuff + (i * 2048);
 		rxqueue->buffers[i].Length = RX_BUFFER_SIZE;
@@ -193,7 +198,7 @@ void AuVirtioNetTxinitialize(struct VirtioCommonCfg* common) {
 	uint16_t qsize = common->QueueSize;
 	UARTDebugOut("[aurora]: tx queue size : %d \r\n", qsize);
 	uint64_t queuePhys = (uint64_t)
-		AuPmmngrAlloc(); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+		AuPmmngrAllocPage(AURORA_PAGE_NORMAL); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	txqueue = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
 	common->QueueDesc = queuePhys;
 	common->QueueAvail = (queuePhys) + OFFSETOF(struct VirtioQueue, available);

--- a/KernelAA64/Drivers/virtiotablet.c
+++ b/KernelAA64/Drivers/virtiotablet.c
@@ -215,7 +215,7 @@ void AuVirtioTabletInitialize(uint64_t device) {
 	int queueSz = common->QueueSize;
 	tabletQueueSz = queueSz;
 	uint64_t queuePhys = (uint64_t)
-		AuPmmngrAlloc(); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
+		AuPmmngrAllocPage(AURORA_PAGE_NORMAL); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
 	TabletQueue = (struct VirtioQueue*)AuMapMMIO(
 		queuePhys, 1 /*((sizeof(struct VirtioQueue) * queueSz)) / 0x1000*/);
 	size_t desc_size = queueSz * sizeof(struct VirtioQueue);
@@ -228,7 +228,7 @@ void AuVirtioTabletInitialize(uint64_t device) {
 	isb_flush();
 	dsb_ish();
 
-	uint64_t bufferBase = (uint64_t)AuPmmngrAlloc();
+	uint64_t bufferBase = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	TabletInput = (struct VirtioInputEvent*)AuMapMMIO(bufferBase, 1);
 
 	for (int i = 0; i < queueSz; ++i) {

--- a/KernelAA64/Fs/Ext2/Ext2.c
+++ b/KernelAA64/Fs/Ext2/Ext2.c
@@ -57,7 +57,7 @@ uint32_t Ext2FindEntry(Ext2Fs* fs, Ext2Inode* dir_inode, const char* name) {
 	uint32_t sector_per_block = block_size / 512;
 	uint32_t target_len = strlen(name);
 
-	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	if (!buffer) {
 		AuTextOut("[Ext2]: out of memory during directory scanning.\r\n");
 		return 0;
@@ -79,13 +79,13 @@ uint32_t Ext2FindEntry(Ext2Fs* fs, Ext2Inode* dir_inode, const char* name) {
 			Ext2Dir* entry = (Ext2Dir*)((uint8_t*)buffer + current_pos);
 
 			if (entry->rec_len == 0) {
-				AuPmmngrFree((void*)V2P((uint64_t)buffer));
+				AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 				return 0;
 			}
 			if (entry->inode != 0 && entry->name_len == target_len) {
 				if (strncmp(entry->name, name, entry->name_len) == 0) {
 					uint32_t found_inode = entry->inode;
-					AuPmmngrFree((void*)V2P((uint64_t)buffer));
+					AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 					return found_inode;
 				}
 			}
@@ -94,7 +94,7 @@ uint32_t Ext2FindEntry(Ext2Fs* fs, Ext2Inode* dir_inode, const char* name) {
 		}
 	}
 
-	AuPmmngrFree((void*)V2P((uint64_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 	return 0;
 };
 
@@ -123,7 +123,7 @@ int Ext2ReadInode(Ext2Fs* fs, uint32_t inode_num, Ext2Inode* out_inode) {
 	uint32_t sector_per_block = fs->block_size / 512;
 	uint32_t target_lba = target_physical_block * sector_per_block;
 
-	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	if (!buffer) {
 		AuTextOut("[Ext2]: out of memory during inode reading.\r\n");
 		return -1;
@@ -136,7 +136,7 @@ int Ext2ReadInode(Ext2Fs* fs, uint32_t inode_num, Ext2Inode* out_inode) {
 	uint8_t* target_adress = (uint8_t*)buffer + internal_byte_offset;
 	memcpy(out_inode, target_adress, sizeof(Ext2Inode));
 
-	AuPmmngrFree((void*)V2P((uint64_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 
 	return 0;
 };
@@ -156,7 +156,7 @@ uint32_t Ext2ReadBlockIndex(Ext2Fs* fs, uint32_t block_id, uint32_t index) {
 	uint32_t sector_per_block = fs->block_size / 512;
 	uint64_t target_lba = (uint64_t)block_id * sector_per_block;
 
-	uint32_t* buffer = (uint32_t*)P2V((uint32_t)AuPmmngrAlloc());
+	uint32_t* buffer = (uint32_t*)P2V((uint32_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	if (!buffer) {
 		AuTextOut("[Ext2]: out of memory during block index reading.\r\n");
 		return 0;
@@ -166,7 +166,7 @@ uint32_t Ext2ReadBlockIndex(Ext2Fs* fs, uint32_t block_id, uint32_t index) {
 	AuVDiskRead((AuVDisk*)fs->vdisk, target_lba, sector_per_block, (uint64_t*)buffer);
 	uint32_t resolved_physical_block = buffer[index];
 
-	AuPmmngrFree((void*)V2P((uint64_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 
 	return resolved_physical_block;
 };
@@ -200,7 +200,7 @@ size_t Ext2Read(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t len
 	uint32_t sector_per_block = block_size / 512;
 	uint32_t bytes_read = 0;
 
-	uint64_t* bounce_page = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* bounce_page = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	if (!bounce_page) {
 		AuTextOut("[Ext2]: out of memory during file reading.\r\n");
 		return 0;
@@ -290,7 +290,7 @@ size_t Ext2Read(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t len
 		bytes_read += chunk;
 	}
 
-	AuPmmngrFree((void*)V2P((uint64_t)bounce_page));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)bounce_page));
 	file->pos += bytes_read;
 
 	return bytes_read;
@@ -418,7 +418,7 @@ AuVFSNode* Ext2Open(AuVFSNode* fsys, char* path) {
 * @param mountname -- mount file system name
 */
 AuVFSNode* Ext2Initialise(AuVDisk* vdisk, char* mountname) {
-	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buffer, 0, 4096);
 
 	AuVDiskRead(vdisk, 2, 2, buffer);
@@ -441,7 +441,7 @@ AuVFSNode* Ext2Initialise(AuVDisk* vdisk, char* mountname) {
 	memcpy(fs->superblock, buffer, sizeof(Ext2Superblock));
 
 	if (fs->superblock->magic != EXT2_SUPER_BLOCK_MAGIC) {
-		AuPmmngrFree((void*)V2P((uint64_t)buffer));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 		kfree(fs->superblock);
 		kfree(fs);
 		AuTextOut("[ext2]: EXT2 magic mismatch \n");
@@ -508,7 +508,7 @@ AuVFSNode* Ext2Initialise(AuVDisk* vdisk, char* mountname) {
 	AuVFSAddFileSystem(fsys);
 	AuVFSRegisterRoot(fsys);
 
-	AuPmmngrFree((void*)V2P((uint64_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 
 	return fsys;
 }

--- a/KernelAA64/Fs/Fat/Fat.c
+++ b/KernelAA64/Fs/Fat/Fat.c
@@ -172,12 +172,12 @@ uint32_t FatReadFAT(AuVFSNode* node, uint64_t cluster_index) {
 	uint64_t fat_sector = fs->__FatBeginLBA + (fat_offset / fs->__BytesPerSector);
 
 	size_t ent_offset = fat_offset % fs->__BytesPerSector;
-	uint64_t* BuffArea = (uint64_t*)fs->_scratchBuffer; //P2V((size_t)AuPmmngrAlloc());
+	uint64_t* BuffArea = (uint64_t*)fs->_scratchBuffer; //P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	//memset(BuffArea, 0, 512);
 	AuVDiskRead(vdisk, fat_sector, 1, BuffArea);
 	unsigned char* buf = (unsigned char*)BuffArea;
 	uint32_t value = *(uint32_t*)&buf[ent_offset];
-	//AuPmmngrFree((void*)V2P((size_t)BuffArea));
+	//AuPmmngrReleasePage((uint64_t)V2P((size_t)BuffArea));
 	return (value & 0x0FFFFFFF);
 }
 
@@ -244,7 +244,7 @@ void FatAllocCluster(AuVFSNode* fsys, int position, uint32_t n_value) {
 	uint64_t fat_sector = fs->__FatBeginLBA + (fat_offset / 512);
 	size_t ent_offset = fat_offset % 512;
 
-	uint32_t* buffer = (uint32_t*)P2V((size_t)AuPmmngrAlloc());
+	uint32_t* buffer = (uint32_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buffer, 0, PAGE_SIZE);
 	AuVDiskRead(vdisk, fat_sector, 1, (uint64_t*)buffer);
 	uint8_t* buf = (uint8_t*)buffer;
@@ -254,7 +254,7 @@ void FatAllocCluster(AuVFSNode* fsys, int position, uint32_t n_value) {
 	*(uint32_t*)&buf[ent_offset] = n_value & 0x0FFFFFFF;
 
 	AuVDiskWrite(vdisk, fat_sector, 1, (uint64_t*)buffer);
-	AuPmmngrFree((void*)V2P((size_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buffer));
 }
 
 /**
@@ -269,12 +269,12 @@ void FatClearCluster(AuVFSNode* node, uint32_t cluster) {
 
 	uint32_t val = FatReadFAT(node, cluster);
 
-	uint64_t* buffer = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buffer = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buffer, 0, PAGE_SIZE);
 	//update_cluster (buffer,cluster);
 	uint64_t sector = FatClusterToSector32(fs, cluster);
 	AuVDiskWrite(vdisk, sector, fs->__SectorPerCluster, buffer);
-	AuPmmngrFree((void*)V2P((size_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buffer));
 }
 
 /**
@@ -332,8 +332,7 @@ size_t FatReadFile(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer, uint32_t 
 
 	FatFS* fs = (FatFS*)fsys->device;
 
-	uint64_t read_bytes = 0;
-	size_t ret_bytes = 0;
+	size_t copied_bytes = 0;
 	uint8_t* aligned_buffer = (uint8_t*)buffer;
 
 	size_t skip = file->pos % fs->cluster_sz_in_bytes;
@@ -346,7 +345,7 @@ size_t FatReadFile(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer, uint32_t 
 	size_t avail = 0;
 	size_t to_copy = 0;
 
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	for (int i = 0; i < num_blocks; i++) {
 		if (file->eof)
 			break;
@@ -355,24 +354,18 @@ size_t FatReadFile(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer, uint32_t 
 		to_copy = (length < avail) ? length : avail;
 
 		//	memset(buff, 0, PAGE_SIZE);
-		read_bytes = FatRead(fsys, file, buff);
+		FatRead(fsys, file, buff);
 		memcpy(aligned_buffer, (uint8_t*)buff + skip, to_copy);
 		aligned_buffer += to_copy;
 		length -= to_copy;
-		ret_bytes += read_bytes;
+		copied_bytes += to_copy;
 	}
 
 	// reset the position in bytes value
 	file->pos = 0;
 
-	/* Okay, might be we read one block, but length was less
-	 * then 4KiB, just return that length
-	 */
-	if (length < ret_bytes)
-		ret_bytes = length;
-
-	AuPmmngrFree((void*)V2P((size_t)buff));
-	return ret_bytes;
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
+	return copied_bytes;
 }
 
 AuVFSNode* FatLocateSubDir(AuVFSNode* fsys, AuVFSNode* kfile, const char* filename) {
@@ -385,7 +378,7 @@ AuVFSNode* FatLocateSubDir(AuVFSNode* fsys, AuVFSNode* kfile, const char* filena
 	memset(dos_file_name, 0, 11);
 	FatToDOSFilename(filename, dos_file_name, 11);
 	dos_file_name[11] = 0;
-	uint64_t* buf = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buf = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	if (kfile->flags != FS_FLAG_INVALID) {
 		while (1) {
 			if (kfile->eof) {
@@ -416,7 +409,7 @@ AuVFSNode* FatLocateSubDir(AuVFSNode* fsys, AuVFSNode* kfile, const char* filena
 						file->flags |= FS_FLAG_DIRECTORY;
 					else
 						file->flags |= FS_FLAG_GENERAL;
-					AuPmmngrFree((void*)V2P((size_t)buf));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 					kfree(kfile);
 					return file;
 				}
@@ -426,7 +419,7 @@ AuVFSNode* FatLocateSubDir(AuVFSNode* fsys, AuVFSNode* kfile, const char* filena
 		}
 	}
 
-	AuPmmngrFree((void*)V2P((size_t)buf));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 	kfree(file);
 	if (kfile)
 		kfree(kfile);
@@ -455,7 +448,7 @@ AuVFSNode* FatLocateDir(AuVFSNode* fsys, const char* dir) {
 	FatToDOSFilename(dir, dos_file_name, 11);
 	//dos_file_name[10] = '\0';
 
-	buf = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	buf = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buf, 0, PAGE_SIZE);
 
 	uint32_t current_cluster = fs->__RootDirFirstCluster;
@@ -491,7 +484,7 @@ AuVFSNode* FatLocateDir(AuVFSNode* fsys, const char* dir) {
 					else
 						file->flags |= FS_FLAG_GENERAL;
 					aa64_data_cache_clean_range(file, sizeof(AuVFSNode));
-					AuPmmngrFree((void*)V2P((size_t)buf));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 					return file;
 				}
 				dirent++;
@@ -610,7 +603,7 @@ uint32_t FatGetDiskBlock(AuVFSNode* fs, AuVFSNode* file, uint64_t fs_block) {
 * @param mountname -- mount file system name
 */
 AuVFSNode* FatInitialise(AuVDisk* vdisk, char* mountname) {
-	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* buffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buffer, 0, 4096);
 	AuVDiskRead(vdisk, 0, 1, buffer);
 
@@ -664,7 +657,7 @@ AuVFSNode* FatInitialise(AuVDisk* vdisk, char* mountname) {
 	fs->__TotalClusters = bpb.large_sector_count / fs->__SectorPerCluster;
 	fs->__LastIndexInFat = 0;
 	fs->__LastIndexSector = 0;
-	fs->_scratchBuffer = (void*)P2V((uint64_t)AuPmmngrAlloc());
+	fs->_scratchBuffer = (void*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(fs->_scratchBuffer, 0, PAGE_SIZE);
 	size_t _root_dir_sectors =
 		((bpb.num_dir_entries * 32) + bpb.bytes_per_sector - 1) / bpb.bytes_per_sector;
@@ -687,7 +680,7 @@ AuVFSNode* FatInitialise(AuVDisk* vdisk, char* mountname) {
 		fs->fatType = FSTYPE_FAT32;
 
 	if (fs->fatType != FSTYPE_FAT32) {
-		AuPmmngrFree(buffer);
+		AuPmmngrReleasePage((uint64_t)buffer);
 		kfree(fs);
 		return NULL;
 	}
@@ -713,7 +706,7 @@ AuVFSNode* FatInitialise(AuVDisk* vdisk, char* mountname) {
 	AuVFSAddFileSystem(fsys);
 	AuVFSRegisterRoot(fsys);
 
-	AuPmmngrFree((void*)V2P((uint64_t)buffer));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)buffer));
 
 	return fsys;
 }

--- a/KernelAA64/Fs/Fat/FatDir.c
+++ b/KernelAA64/Fs/Fat/FatDir.c
@@ -69,7 +69,7 @@ AuVFSNode* FatCreateDir(AuVFSNode* fsys, char* filename) {
 	AuVFSNode* file = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
 	memset(file, 0, sizeof(AuVFSNode));
 
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 
 	/* now extract only the filename from
@@ -127,7 +127,7 @@ AuVFSNode* FatCreateDir(AuVFSNode* fsys, char* filename) {
 					dirent->date_last_accessed = 0;
 					dirent->file_size = 0;
 
-					uint8_t* entrybuf = (uint8_t*)P2V((size_t)AuPmmngrAlloc());
+					uint8_t* entrybuf = (uint8_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 					memset(entrybuf, 0, PAGE_SIZE);
 
 					FatDir* dot_entry = (FatDir*)entrybuf;
@@ -173,8 +173,8 @@ AuVFSNode* FatCreateDir(AuVFSNode* fsys, char* filename) {
 					aa64_data_cache_clean_range(buff, PAGE_SIZE);
 					AuVDiskWrite(_fs->vdisk, FatClusterToSector32(_fs, parent_clust) + j, 1, buff);
 
-					AuPmmngrFree((void*)V2P((size_t)entrybuf));
-					AuPmmngrFree((void*)V2P((size_t)buff));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)entrybuf));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 
 					strcpy(file->filename, extract);
 					file->size = 0;
@@ -199,7 +199,7 @@ AuVFSNode* FatCreateDir(AuVFSNode* fsys, char* filename) {
 			break;
 	}
 
-	AuPmmngrFree((void*)V2P((size_t)buff));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 	kfree(parent);
 	kfree(file);
 	return NULL;
@@ -223,7 +223,7 @@ int FatRemoveDir(AuVFSNode* fsys, AuVFSNode* file) {
 
 	bool _is_empty = true;
 
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 	/* verify, if the directory is empty*/
 	while (1) {
@@ -238,7 +238,7 @@ int FatRemoveDir(AuVFSNode* fsys, AuVFSNode* file) {
 				name[10] = 0;
 
 				if ((dirent->filename[0] != 0x00) && (dirent->filename[0] != 0xE5)) {
-					AuPmmngrFree((void*)V2P((size_t)buff));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 					_is_empty = false;
 					break;
 				}
@@ -320,12 +320,12 @@ int FatDirectoryRead(AuVFSNode* fs, AuVFSNode* dir, AuDirectoryEntry* dirent) {
 	FatFS* fatfs = (FatFS*)fs->device;
 	AuVDisk* vdisk = (AuVDisk*)fatfs->vdisk;
 
-	uint64_t* buf = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* buf = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buf, 0, PAGE_SIZE);
 
 	if ((index / 16) > fatfs->__SectorPerCluster) {
 		dirent->index = -1;
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		return -1;
 	}
 
@@ -335,36 +335,36 @@ int FatDirectoryRead(AuVFSNode* fs, AuVFSNode* dir, AuDirectoryEntry* dirent) {
 
 	if (dir_->filename[0] == 0x00) {
 		dirent->index = -1;
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		return -1;
 	}
 
 	if (dir_->filename[0] == 0xE5 || dir_->filename[0] == 0x05 || dir_->filename[0] == 0xFF) {
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		dirent->index += 1;
 		return -1;
 	}
 
 	if (dir_->attrib & 0x02) {
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		dirent->index += 1;
 		return -1;
 	}
 
 	if (dir_->attrib & 0x04) {
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		dirent->index += 1;
 		return -1;
 	}
 
 	if (dir_->attrib & 0x08) {
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		dirent->index += 1;
 		return -1;
 	}
 
 	if (dir_->attrib & 0x01) {
-		AuPmmngrFree((void*)V2P((size_t)buf));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 		dirent->index += 1;
 		return -1;
 	}
@@ -387,7 +387,7 @@ int FatDirectoryRead(AuVFSNode* fs, AuVFSNode* dir, AuDirectoryEntry* dirent) {
 		dirent->flags = FS_FLAG_DIRECTORY;
 	if (dir_->attrib & 0x20)
 		dirent->flags = FS_FLAG_GENERAL;
-	AuPmmngrFree((void*)V2P((size_t)buf));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buf));
 	dirent->index += 1;
 	return 0;
 }

--- a/KernelAA64/Fs/Fat/FatFile.c
+++ b/KernelAA64/Fs/Fat/FatFile.c
@@ -58,6 +58,11 @@ AuVFSNode* FatFileGetParent(AuVFSNode* fsys, const char* filename) {
 	AuVFSNode* parent = NULL;
 
 	AuVFSNode* retfile = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
+	/* retfile gets memcpy'd into and dereferenced below with no NULL check,
+	 * on kmalloc exhaustion that was a guaranteed NULL deref and a
+	 * system crash --axiss */
+	if (!retfile)
+		return NULL;
 
 	char* path = (char*)filename;
 	char* p = strchr(path, '/');
@@ -65,8 +70,11 @@ AuVFSNode* FatFileGetParent(AuVFSNode* fsys, const char* filename) {
 		p++;
 	bool is_root = true;
 
-	//skip alphabet label
-	if (fsys != __RootFS)
+	/* skip alphabet label. this ran unconditionally, so on a filename with
+	 * no '/' at all (p == NULL here) it walked p up to (char*)0x2 and the
+	 * while(p) loop below happily treated that garbage as a valid pointer
+	 * and dereferenced it --axiss */
+	if (fsys != __RootFS && p)
 		p += 2;
 
 	while (p) {
@@ -126,7 +134,7 @@ AuVFSNode* FatCreateFile(AuVFSNode* fsys, char* filename) {
 	AuVFSNode* file = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
 	memset(file, 0, sizeof(AuVFSNode));
 
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 
 	char* path = (char*)filename;
@@ -183,7 +191,7 @@ AuVFSNode* FatCreateFile(AuVFSNode* fsys, char* filename) {
 
 					AuVDiskWrite(_fs->vdisk, sector + j, 1, buff);
 
-					AuPmmngrFree((void*)V2P((size_t)buff));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 
 					strcpy(file->filename, extract);
 					file->size = dirent->file_size;
@@ -234,7 +242,7 @@ void FatFileUpdateSize(AuVFSNode* fsys, AuVFSNode* file, size_t size) {
 	memset(fname, 0, 11);
 	FatToDOSFilename(file->filename, fname, 11);
 	//fname[11] = 0;
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 
 	while (1) {
@@ -251,7 +259,7 @@ void FatFileUpdateSize(AuVFSNode* fsys, AuVFSNode* file, size_t size) {
 				if (strcmp(fname, name) == 0) {
 					dirent->file_size += size;
 					AuVDiskWrite(_fs->vdisk, FatClusterToSector32(_fs, dir_cluster) + j, 1, buff);
-					AuPmmngrFree((void*)V2P((size_t)buff));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 					return;
 				}
 				dirent++;
@@ -293,7 +301,7 @@ int FatFileUpdateFilename(AuVFSNode* fsys, AuVFSNode* file, char* newname) {
 	FatToDOSFilename(newname, nname, 11);
 	//nname[11] = 0;
 
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 
 	while (1) {
@@ -310,7 +318,7 @@ int FatFileUpdateFilename(AuVFSNode* fsys, AuVFSNode* file, char* newname) {
 				if (strcmp(name, fname) == 0) {
 					memcpy(dirent->filename, nname, 11);
 					AuVDiskWrite(_fs->vdisk, FatClusterToSector32(_fs, dir_cluster) + j, 1, buff);
-					AuPmmngrFree((void*)V2P((size_t)buff));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 					return 0;
 				}
 				dirent++;
@@ -337,7 +345,7 @@ void FatFileWriteContent(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer) {
 
 	FatFS* _fs = (FatFS*)fsys->device;
 
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 
 	uint32_t cluster = file->current;
@@ -353,7 +361,9 @@ void FatFileWriteContent(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer) {
 		file->eof = 0;
 	}
 
-	if ((cluster != (FAT_EOC_MARK & 0x0FFFFFFF)) || (cluster != (FAT_BAD_CLUSTER & 0x0fffffff))) {
+	/* this was || before, which can never be false, so EOC/BAD clusters
+	 * never actually got skipped here --axiss */
+	if ((cluster != (FAT_EOC_MARK & 0x0FFFFFFF)) && (cluster != (FAT_BAD_CLUSTER & 0x0fffffff))) {
 		memcpy(buff, buffer, PAGE_SIZE);
 		AuVDiskWrite(_fs->vdisk, FatClusterToSector32(_fs, cluster), _fs->__SectorPerCluster, buff);
 		file->pos++;
@@ -368,7 +378,7 @@ void FatFileWriteContent(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer) {
 	file->size = file->pos * _fs->__SectorPerCluster * _fs->__BytesPerSector;
 	size_t sz = file->size;
 
-	AuPmmngrFree((void*)V2P((size_t)buff));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 }
 
 /*
@@ -382,8 +392,8 @@ void FatFileWriteDone(AuVFSNode* file) {
 	file->pos = 0;
 }
 
-/*
- * FatWrite -- write callback
+/**
+ * @brief FatWrite -- write callback
  * @param fsys -- pointer to file system
  * @param file -- pointer to file
  * @param buffer -- buffer to write
@@ -397,18 +407,21 @@ size_t FatWrite(AuVFSNode* fsys, AuVFSNode* file, uint64_t* buffer, uint32_t len
 	size_t num_cluster = length / ((_fs->__BytesPerSector) * _fs->__SectorPerCluster) +
 						 ((length % (_fs->__BytesPerSector * _fs->__SectorPerCluster) ? 1 : 0));
 
+	/* buffer is a uint64_t*, so a plain `buffer += clusterSize` advanced
+	 * 8x too far since pointer arithmetic scales by sizeof(uint64_t),
+	 * corrupted every cluster after the first on any write > 4KB --axiss */
+	uint8_t* byte_buffer = (uint8_t*)buffer;
 	for (int i = 0; i < num_cluster; i++) {
-		FatFileWriteContent(fsys, file, buffer);
-		buffer += (_fs->__BytesPerSector * _fs->__SectorPerCluster);
+		FatFileWriteContent(fsys, file, (uint64_t*)byte_buffer);
+		byte_buffer += (_fs->__BytesPerSector * _fs->__SectorPerCluster);
 	}
 
 	FatFileUpdateSize(fsys, file, length);
 	//FatFileWriteDone(file);
 	return length;
 }
-
-/*
- * FatFileClearDirEntry -- clears an entry of a directory
+/**
+ * @brief FatFileClearDirEntry -- clears an entry of a directory
  * @param fsys -- Pointer to file system node
  * @param file -- Pointer to file
  */
@@ -422,7 +435,8 @@ int FatFileClearDirEntry(AuVFSNode* fsys, AuVFSNode* file) {
 
 	uint32_t dir_clust = file->parent_block;
 	if (!dir_clust) {
-		//SeTextOut("FatFileClearDirEntry: no parent directory %x \r\n", dir_clust);
+		// If no parent directory, we can't clear the entry
+		UARTDebugOut("FatFileClearDirEntry: no parent directory %x \r\n", dir_clust);
 		return 1;
 	}
 
@@ -431,7 +445,7 @@ int FatFileClearDirEntry(AuVFSNode* fsys, AuVFSNode* file) {
 	FatToDOSFilename(file->filename, fname, 11);
 	//fname[11] = 0;
 	//SeTextOut("Dir clust -> %x \r\n", dir_clust);
-	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(buff, 0, PAGE_SIZE);
 
 	while (1) {
@@ -449,7 +463,7 @@ int FatFileClearDirEntry(AuVFSNode* fsys, AuVFSNode* file) {
 					//SeTextOut("Dir clearing found \r\n");
 					dirent->filename[0] = 0xE5;
 					AuVDiskWrite(_fs->vdisk, FatClusterToSector32(_fs, dir_clust) + j, 1, buff);
-					AuPmmngrFree((void*)V2P((size_t)buff));
+					AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
 					return 0;
 				}
 				dirent++;
@@ -462,9 +476,8 @@ int FatFileClearDirEntry(AuVFSNode* fsys, AuVFSNode* file) {
 	}
 	return -1;
 }
-
-/*
- * FatFileRemove -- remove a file
+/**
+ * @brief FatFileRemove -- remove a file
  * @param fsys -- Pointer to file
  * @param file -- file to remove
  */

--- a/KernelAA64/Fs/fsprobe.c
+++ b/KernelAA64/Fs/fsprobe.c
@@ -57,7 +57,7 @@ aurora_fs_type AuProbeFileSystem(AuVDisk* vdisk) {
 	if (!vdisk->Read)
 		return 0;
 
-	uint8_t* sector = (uint8_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint8_t* sector = (uint8_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(sector, 0, 512);
 
 	vdisk->Read(vdisk, 0, 1, sector);
@@ -67,19 +67,19 @@ aurora_fs_type AuProbeFileSystem(AuVDisk* vdisk) {
 	// 9 characters
 	if (memcmp(sector + 0x03, "NTFS    ", 8) == 0) {
 		UARTDebugOut("ntfs \r\n");
-		AuPmmngrFree((void*)V2P((uint64_t)sector));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)sector));
 		return AURORA_FS_NTFS;
 	}
 
 	if (memcmp(sector + 0x52, "FAT32   ", 8) == 0) {
 		UARTDebugOut("fat32 \r\n");
-		AuPmmngrFree((void*)V2P((uint64_t)sector));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)sector));
 		return AURORA_FS_FAT32;
 	}
 
 	if (memcmp(sector + 0x36, "FAT16   ", 8) == 0) {
 		UARTDebugOut("fat16 \r\n");
-		AuPmmngrFree((void*)V2P((uint64_t)sector));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)sector));
 		return AURORA_FS_FAT16;
 	}
 
@@ -90,10 +90,10 @@ aurora_fs_type AuProbeFileSystem(AuVDisk* vdisk) {
 
 	uint16_t ext_magic = *(uint16_t*)(sector + 0x38);
 	if (ext_magic == 0xEF53) {
-		AuPmmngrFree((void*)V2P((uint64_t)sector));
+		AuPmmngrReleasePage((uint64_t)V2P((uint64_t)sector));
 		return AURORA_FS_EXT2;
 	}
 
-	AuPmmngrFree((void*)V2P((uint64_t)sector));
+	AuPmmngrReleasePage((uint64_t)V2P((uint64_t)sector));
 	return AURORA_FS_UNKNOWN;
 }

--- a/KernelAA64/Fs/vdisk.c
+++ b/KernelAA64/Fs/vdisk.c
@@ -144,12 +144,37 @@ size_t AuVDiskWrite(AuVDisk* disk, uint64_t lba, uint32_t count, uint64_t* buffe
 }
 
 /**
+ * @brief AuVDiskFlush -- flushes a single registered disk's write
+ * cache, if its driver provides one (no-op otherwise)
+ * @param disk -- Pointer to vdisk structure
+ */
+int AuVDiskFlush(AuVDisk* disk) {
+	if (!disk)
+		return 0;
+	if (disk->Flush)
+		return disk->Flush(disk);
+	return 0;
+}
+
+/**
+ * @brief AuVDiskFlushAll -- flushes every registered disk's write
+ * cache; called before power-down/reset so no dirty device-side
+ * cache is lost
+ */
+void AuVDiskFlushAll() {
+	for (int i = 0; i < MAX_VDISK_DEVICES; i++) {
+		if (VdiskArray[i])
+			AuVDiskFlush(VdiskArray[i]);
+	}
+}
+
+/**
  * @brief AuVDiskRegisterPartition - Gether all informations about the partition
  * for now, only GUID Partition is supported
  * @param vdisk -- VDisk structure pointer
  */
 void AuVDiskRegisterPartition(AuVDisk* vdisk) {
-	uint64_t* buffer = (uint64_t*)AuPmmngrAlloc();
+	uint64_t* buffer = (uint64_t*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset(buffer, 0, 4096);
 	if (!vdisk->Read)
 		return;
@@ -212,7 +237,7 @@ void AuVDiskRegisterPartition(AuVDisk* vdisk) {
 	//AuGPTInitialise_FileSystem(vdisk);
 
 	AuTextOut("\r\n");
-	AuPmmngrFree(buffer);
+	AuPmmngrReleasePage((uint64_t)buffer);
 }
 
 /**

--- a/KernelAA64/Hal/aa64lowlevel.s
+++ b/KernelAA64/Hal/aa64lowlevel.s
@@ -494,11 +494,10 @@ aa64_clean_invalidate_dcache:
    msr csselr_el1, x10
    isb
     
-   mrs x1, ccsidr_el1 
+   mrs x1, ccsidr_el1
    and x2, x1, #7
    add x2, x2, #4
-
-   mov x4, #0x3dd
+   mov x4, #0x3ff
    and x4, x4, x1, lsr #3
    clz w5, w4
    mov x7, #0x7fff

--- a/KernelAA64/Hal/aa64switch.s
+++ b/KernelAA64/Hal/aa64switch.s
@@ -458,14 +458,36 @@ aa64_restore_sp:
    msr SPSR_EL1,x2
    ret
 
+/* This resumes a thread captured by an exception vector.  Switching SP inside
+ * a C call and then returning through that call mixes two threads' call
+ * frames, so we need to restore the architectural frame directly and finish with eret instead --axiss */
+.global aa64_resume_exception_frame
+aa64_resume_exception_frame:
+   mov sp, x0
+   msr ELR_EL1, x1
+   msr SPSR_EL1, x2
+   ldp x30, x0, [sp], #16
+   msr SP_EL0, x0
+   ldp x28, x29, [sp], #16
+   ldp x26, x27, [sp], #16
+   ldp x24, x25, [sp], #16
+   ldp x22, x23, [sp], #16
+   ldp x20, x21, [sp], #16
+   ldp x18, x19, [sp], #16
+   ldp x16, x17, [sp], #16
+   ldp x14, x15, [sp], #16
+   ldp x12, x13, [sp], #16
+   ldp x10, x11, [sp], #16
+   ldp x8, x9, [sp], #16
+   ldp x6, x7, [sp], #16
+   ldp x4, x5, [sp], #16
+   ldp x2, x3, [sp], #16
+   ldp x0, x1, [sp], #16
+   eret
+
 .global aa64_signal_return
 aa64_signal_return:
     mov x16, 24
     svc #0
     mov x0, x6
     ret
-
-
-    
-
-  

--- a/KernelAA64/Hal/sched.c
+++ b/KernelAA64/Hal/sched.c
@@ -52,6 +52,8 @@ extern bool aa64_restore_context(AA64Thread* thr);
 extern void aa64_restore_sp(AA64Thread* thr);
 extern void aa64_schedule_init(AA64Thread* current, AA64Thread* init, uint64_t va);
 extern void ret_from_syscall(AA64Thread* thr);
+extern void aa64_resume_exception_frame(AA64Registers* regs,
+	uint64_t elr_el1, uint64_t spsr_el1) __attribute__((noreturn));
 
 extern void first_time_sex(AA64Thread* thr);
 extern void first_time_sex2(AA64Thread* thr);
@@ -263,7 +265,10 @@ AA64Thread* AuCreateKthread(void (*entry)(uint64_t), uint64_t* pml, char* name) 
 	t->name[7] = '\0';
 	t->elr_el1 = (uint64_t)entry;
 	t->x30 = (uint64_t)entry;
-	t->spsr_el1 = 0x3C4; //0x3C4; // 0x245;
+	/* running kernel trampolines at EL1h on their own kernel SP. EL1t wouldve
+	 * run on SP_EL0 and aa64_enter_user would yank that stack out from
+	 * under it before eret --axiss */
+	t->spsr_el1 = 0x3C5;
 	//t->sp = stack;
 	t->pml = (uint64_t)pml;
 	t->sp = AuCreateKernelStack((uint64_t*)t->pml);
@@ -295,7 +300,7 @@ AA64Thread* AuCreateSubKthread(void (*entry)(uint64_t), uint64_t stack, uint64_t
 	t->name[7] = '\0';
 	t->elr_el1 = (uint64_t)entry;
 	t->x30 = (uint64_t)entry;
-	t->spsr_el1 = 0x3C4; //0x3C4; // 0x245;
+	t->spsr_el1 = 0x3C5;
 	//t->sp = stack;
 	t->pml = (uint64_t)pml;
 	t->sp = stack;
@@ -385,23 +390,31 @@ void AuThreadSafeReturn(uint64_t rcx) {
  */
 void AuScheduleThread(AA64Registers* regs) {
 	mask_irqs();
-	if (_scheduler_initialized == 0) {
+	if (_scheduler_initialized == 0 || !regs) {
 		return;
 	}
 	AA64Thread* runThr = current_thread;
 
-	aa64_store_context(runThr);
+	/* the vector wrapper already captured the full interrupted register set,
+	 * so i treat this frame as the only valid resume point for a preempted
+	 * thread, not a C call frame and not originalKSp --axiss */
 	runThr->sp = (uint64_t)regs;
+	runThr->elr_el1 = read_elr_el1();
+	runThr->spsr_el1 = read_spsr_el1();
+	runThr->x0 = regs->x0; runThr->x1 = regs->x1;
+	runThr->x2 = regs->x2; runThr->x3 = regs->x3;
+	runThr->x4 = regs->x4; runThr->x5 = regs->x5;
+	runThr->x6 = regs->x6; runThr->x7 = regs->x7;
+	runThr->x8 = regs->x8;
+	runThr->x19 = regs->x19; runThr->x20 = regs->x20;
+	runThr->x21 = regs->x21; runThr->x22 = regs->x22;
+	runThr->x23 = regs->x23; runThr->x24 = regs->x24;
+	runThr->x25 = regs->x25; runThr->x26 = regs->x26;
+	runThr->x27 = regs->x27; runThr->x28 = regs->x28;
+	runThr->x29 = regs->x29; runThr->x30 = regs->x30;
+	runThr->justStored = true;
 
-sched:
 	aa64_store_fp(runThr->fp_regs, (uint64_t*)&runThr->fpcr, (uint64_t*)&runThr->fpsr);
-
-	if (regs) {
-		runThr->x0 = regs->x0;
-		runThr->x1 = regs->x1;
-		runThr->x30 = regs->x30;
-		runThr->x29 = regs->x29;
-	}
 
 	uint64_t now = AuGetCurrentUS();
 	uint64_t delta = now - runThr->start_time_us;
@@ -447,19 +460,20 @@ sched:
 
 	AuSignalDeliver(current_thread);
 
-	if ((current_thread->threadType & THREAD_LEVEL_USER) && current_thread->first_run == 1) {
-		uint64_t sp = current_thread->sp;
-		//current_thread->sp = current_thread->originalKSp;
-		resume_user(current_thread, (void*)sp);
+	if (!current_thread->justStored) {
+		/* first_time_sex (lol) installs the initial kernel entry, stack and
+		 * PSTATE and never returns. user threads go through
+		 * AuProcessEntUser instead, which builds their EL0 stack before
+		 * its own eret --axiss */
+		first_time_sex(current_thread); //unskippable function name holy shit --axiss
+		__builtin_unreachable();
 	}
 
-	current_thread->sp = current_thread->originalKSp;
-	current_thread->data = regs;
-	if (aa64_restore_context(current_thread)) {
-		return;
-	}
-ret:
-	return;
+	AA64Registers* return_frame = (AA64Registers*)current_thread->sp;
+	current_thread->data = return_frame;
+	aa64_resume_exception_frame(return_frame,
+		current_thread->elr_el1, current_thread->spsr_el1);
+	__builtin_unreachable();
 }
 
 /**
@@ -489,7 +503,7 @@ uint64_t AuCreateKernelStack(uint64_t* pml) {
 	uint64_t location = KERNEL_STACK_LOCATION;
 	location += (uint64_t)ke_stack_idx * KERNEL_STACK_SIZE;
 	for (int i = 0; i < (KERNEL_STACK_SIZE) / 0x1000; i++) {
-		uint64_t addr = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+		uint64_t addr = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset((void*)addr, 0, PAGE_SIZE);
 		AuMapPage(V2P(addr), (location + (uint64_t)i * 4096), PTE_AP_RW | PTE_NORMAL_MEM);
 	}
@@ -507,7 +521,7 @@ uint64_t AuCreateSubKernelStack(AuProcess* proc, uint64_t* pml) {
 	uint64_t location = KERNEL_STACK_LOCATION;
 	location += proc->_kstack_index_ * KERNEL_STACK_SIZE;
 	for (int i = 0; i < (KERNEL_STACK_SIZE) / 0x1000; i++) {
-		uint64_t addr = (uint64_t)P2V((uint64_t)AuPmmngrAlloc());
+		uint64_t addr = (uint64_t)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset((void*)addr, 0, PAGE_SIZE);
 		AuMapPage(V2P(addr), (location + i * 4096), PTE_AP_RW | PTE_NORMAL_MEM);
 	}

--- a/KernelAA64/Hal/vector.c
+++ b/KernelAA64/Hal/vector.c
@@ -133,9 +133,11 @@ void sync_el1_handler(AA64Registers* regs) {
 		AuDumpRegisters(currthr, regs);
 	}
 
-	size_t totalRam = (AuPmmngrGetTotalMem() * 0x1000) / 1024 / 1024;
-	size_t usedRam = (AuPmmngrGetUsedMem() * 0x1000) / 1024 / 1024;
-	size_t freeRam = (AuPmmngrGetFreeMem() * 0x1000) / 1024 / 1024;
+	AuPmmStats pmm_stats;
+	AuPmmngrGetStats(&pmm_stats);
+	size_t totalRam = (pmm_stats.managed_pages * 0x1000) / 1024 / 1024;
+	size_t usedRam = (pmm_stats.allocated_pages * 0x1000) / 1024 / 1024;
+	size_t freeRam = (pmm_stats.free_pages * 0x1000) / 1024 / 1024;
 	// AuTextOut("Total RAM : %d MiB, Used RAM : %d MiB , Free RAM : %d MiB\r\n", totalRam, usedRam, freeRam);
 
 	AuProcess* proc = NULL;

--- a/KernelAA64/Ipc/postbox.c
+++ b/KernelAA64/Ipc/postbox.c
@@ -95,7 +95,7 @@ extern uint64_t read_sp();
 void PostBoxCreate(bool root, uint16_t tid) {
 	PostBox* box = (PostBox*)kmalloc(sizeof(PostBox));
 	memset(box, 0, sizeof(PostBox));
-	box->address = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	box->address = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(box->address, 0, PAGE_SIZE);
 
 	if (root && !_PostBoxRootCreated) {
@@ -144,7 +144,7 @@ void PostBoxDestroy(PostBox* box) {
 		box->next->prev = box->prev;
 	}
 
-	AuPmmngrFree((void*)V2P((size_t)box->address));
+	AuPmmngrReleasePage((uint64_t)V2P((size_t)box->address));
 	kfree(box);
 	UARTDebugOut("[postbox]: destroyed for id \r\n");
 }

--- a/KernelAA64/Makefile
+++ b/KernelAA64/Makefile
@@ -31,7 +31,7 @@ ifeq ($(TOOLCHAIN), llvm)
     LLVM_TARGET = -target aarch64-unknown-windows
     
     CFLAGS  = -Wall -Wextra -ffreestanding -fno-stack-protector -fno-stack-check -fno-strict-aliasing \
-              -O0 -g -gdwarf-4 $(LLVM_TARGET) -fno-builtin \
+              -O2 -g -gdwarf-4 $(LLVM_TARGET) -fno-builtin \
               -DARCH_ARM64 $(BOARD_FLAG) -D__STDC_LIMIT_MACROS \
               -Wno-error=incompatible-pointer-types -Wno-error=int-conversion \
               -Wno-implicit-function-declaration -Wno-error=conflicting-types $(INCLUDES)

--- a/KernelAA64/Mm/dma.c
+++ b/KernelAA64/Mm/dma.c
@@ -77,14 +77,18 @@ static AuDMAPage* _dma_pool_add_page(AuDMAPool* pool) {
 	 * and return, but for now aurora following very straigt
 	 * forward method
 	 */
-	page->phys = (uint64_t)AuPmmngrAlloc();
+	page->phys = (uint64_t)AuPmmngrAllocPages(1, 1, 0, AURORA_PAGE_DMA);
+	if (!page->phys) {
+		kfree(page);
+		return NULL;
+	}
 	page->virt = (void*)P2V((uint64_t)page->phys);
 
 	page->slots = pool->slots_per_page;
 	page->bitmap = (uint8_t*)kmalloc(__bitmap_bytes(page->slots));
 	if (!page->bitmap) {
 		UARTDebugOut("[aurora]: dma-pool failed to allocate bitmap \r\n");
-		AuPmmngrFree((void*)page->phys);
+		AuPmmngrReleasePage((uint64_t)page->phys);
 		kfree(page);
 		return NULL;
 	}
@@ -275,7 +279,7 @@ void AuDMAPoolDestroy(AuDMAPool* pool) {
 	while (page) {
 		AuDMAPage* next = page->next;
 		kfree(page->bitmap);
-		AuPmmngrFree((void*)page->phys);
+		AuPmmngrReleasePage((uint64_t)page->phys);
 		kfree(page);
 		page = next;
 	}
@@ -357,7 +361,11 @@ void* AuDMAGClassAlloc(AuDMAGlobalClass* gClass, size_t sz, uint64_t* physOut) {
 
 	if (idx < 0) {
 		/** return a full 4KiB page for larger than MAX_POOL_SZ */
-		return AuPmmngrAlloc();
+		uint64_t phys = (uint64_t)AuPmmngrAllocPages(1, 1, 0, AURORA_PAGE_DMA);
+		if (!phys)
+			return NULL;
+		*physOut = phys;
+		return (void*)P2V(phys);
 	}
 
 	/** or allocate it using pool allocator */
@@ -378,7 +386,7 @@ void AuDMAGClassFree(AuDMAGlobalClass* gClass, void* virt, uint64_t physOut, siz
 	int idx = _dma_gclass_find_class(gClass, sz);
 
 	if (idx < 0) {
-		AuPmmngrFree((void*)physOut);
+		AuPmmngrReleasePage((uint64_t)physOut);
 		return;
 	}
 

--- a/KernelAA64/Mm/kmalloc.c
+++ b/KernelAA64/Mm/kmalloc.c
@@ -54,7 +54,7 @@ void* au_request_page(int pages) {
 	uint64_t page_addr = _brk_current;
 
 	for (int i = 0; i < pages; i++) {
-		void* p = AuPmmngrAlloc();
+		void* p = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		AuMapPage((uint64_t)(size_t)p, page_addr + (size_t)(i * 4096), PTE_NORMAL_MEM);
 	}
 

--- a/KernelAA64/Mm/liballoc.c
+++ b/KernelAA64/Mm/liballoc.c
@@ -608,7 +608,7 @@ void* liballoc_alloc(int pages) {
 	char* page = (char*)AuGetFreePage(0, false);
 	uint64_t page_ = (uint64_t)page;
 	for (size_t i = 0; i < pages; i++) {
-		void* p = AuPmmngrAlloc();
+		void* p = AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		AuMapPage((uint64_t)p, page_ + i * 4096, PTE_NORMAL_MEM);
 	}
 	memset(page, 0, pages * PAGE_SIZE);

--- a/KernelAA64/Mm/mmap.c
+++ b/KernelAA64/Mm/mmap.c
@@ -221,11 +221,11 @@ void* CreateMemMapping(void* address, size_t len, int prot, int flags, int fd, u
 		else {
 			if (fb) {
 				if (AuMmngrFileCacheGetPhysicalBlock(fb, offset) == UINT64_MAX) {
-					phys = (uint64_t)AuPmmngrAlloc();
+					phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 				} else {
 					if (flags & MEMMAP_FLAG_COW) {
 						uint64_t datablk = AuMmngrFileCacheGetPhysicalBlock(fb, offset);
-						phys = (uint64_t)AuPmmngrAlloc();
+						phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 						memcpy((void*)P2V(phys), (void*)P2V(datablk), PAGE_SIZE);
 
 					} else {
@@ -234,7 +234,7 @@ void* CreateMemMapping(void* address, size_t len, int prot, int flags, int fd, u
 				}
 
 			} else {
-				phys = (uint64_t)AuPmmngrAlloc();
+				phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 			}
 		}
 
@@ -245,7 +245,7 @@ void* CreateMemMapping(void* address, size_t len, int prot, int flags, int fd, u
 			if (AuMmngrFileCacheGetPhysicalBlock(fb, offset) == UINT64_MAX) {
 				uint64_t datablk = phys;
 				if (flags & MEMMAP_FLAG_COW) {
-					datablk = (uint64_t)AuPmmngrAlloc();
+					datablk = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 					if (!file->eof)
 						AuVFSNodeReadBlock(fsys, file, (uint64_t*)P2V(datablk));
 					memcpy((void*)P2V(phys), (void*)P2V(datablk), PAGE_SIZE);
@@ -392,7 +392,7 @@ void UnmapMemMapping(void* address, size_t len) {
 		if (page) {
 			uint64_t phys = page->bits.page << PAGE_SHIFT;
 			if (phys) {
-				AuPmmngrFree((void*)phys);
+				AuPmmngrReleasePage((uint64_t)phys);
 			}
 			page->bits.page = 0;
 			isb_flush();

--- a/KernelAA64/Mm/mmfile.c
+++ b/KernelAA64/Mm/mmfile.c
@@ -197,10 +197,8 @@ void AuMmngrFileBackAddPageCache(AuMMFileBack* fileb, AuMMPageCache* cache) {
 		fileb->pageCacheLast->next = cache;
 		cache->prev = fileb->pageCacheLast;
 	}
-	AuPageDesc* desc = AuPmmngrGetPageDesc(cache->physicalPage);
-
-	if (desc && (cache->diskBlock != -1))
-		desc->diskblock = cache->diskBlock;
+	if (cache->diskBlock != -1)
+		AuPmmngrSetBackingBlock(cache->physicalPage, cache->diskBlock);
 
 	fileb->pageCacheLast = cache;
 }

--- a/KernelAA64/Mm/mmserv.c
+++ b/KernelAA64/Mm/mmserv.c
@@ -127,10 +127,10 @@ uint64_t GetProcessHeapMem(size_t sz) {
 
 	uint64_t start_addr = (uint64_t)AuGetFreePage(false, (void*)proc->proc_mem_heap);
 	for (int i = 0; i < sz / PAGE_SIZE; i++) {
-		uint64_t phys = (uint64_t)AuPmmngrAlloc();
+		uint64_t phys = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (!AuMapPage(phys, start_addr + i * PAGE_SIZE, PTE_AP_RW_USER | PTE_NORMAL_MEM)) {
 			UARTDebugOut("already present %x \r\n", (start_addr + i * 0x1000));
-			AuPmmngrFree((void*)phys);
+			AuPmmngrReleasePage((uint64_t)phys);
 		}
 	}
 	isb_flush();
@@ -175,7 +175,7 @@ int ProcessHeapUnmap(void* ptr, size_t sz) {
 			uint64_t phys_page = page_->bits.page << PAGE_SHIFT;
 			//UARTDebugOut("Unmap phys page : %x \n", phys_page);
 			if (phys_page) {
-				AuPmmngrFree((void*)phys_page);
+				AuPmmngrReleasePage((uint64_t)phys_page);
 				//page_->raw = 0;
 				page_->bits.present = 0;
 				isb_flush();

--- a/KernelAA64/Mm/pmmngr.c
+++ b/KernelAA64/Mm/pmmngr.c
@@ -1,527 +1,439 @@
-/**
-* @file pmmngr.c
-* 
-* BSD 2-Clause License
-*
-* Copyright (c) 2022-2025, Manas Kamal Choudhury
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following conditions are met:
-*
-* 1. Redistributions of source code must retain the above copyright notice, this
-*    list of conditions and the following disclaimer.
-*
-* 2. Redistributions in binary form must reproduce the above copyright notice,
-*    this list of conditions and the following disclaimer in the documentation
-*    and/or other materials provided with the distribution.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*
-**/
-
+/** ARM64 region-aware buddy physical-memory manager. */
 #include <Mm/pmmngr.h>
-#include <Hal/AA64/aa64lowlevel.h>
 #include <Mm/vmmngr.h>
-#include <Drivers/uart.h>
+#include <Hal/AA64/aa64lowlevel.h>
+#include <Sync/spinlock.h>
 #include <efi.h>
-#include <Hal/AA64/profile.h>
 #include <aucon.h>
 #include <string.h>
+#include <stdint.h>
+#include <_null.h>
 
 #define PAGE_SHIFT 12
+#define PAGE_SIZE (1ULL << PAGE_SHIFT)
+#define PMM_MAX_ORDER 32
+#define PMM_MAX_REGIONS 128
+#define PMM_MAX_RESERVATIONS 1024
+#define PMM_NO_PAGE UINT64_MAX
 
-static uint64_t _FreeMemory;
-static uint64_t _ReservedMemory;
-static uint64_t _UsedMemory;
-static uint64_t _RamBitmapIndex;
-static uint64_t _TotalRam;
-static uint64_t UsablePhysicalMemory;
-static uint64_t _BitmapSize;
-static bool _HigherHalf;
-bool debugon;
-static uint8_t* BitmapBuffer;
-static AuPageDesc* page_desc;
-static uint32_t total_page_desc_count;
+enum PmmPageState { PMM_PAGE_UNMANAGED, PMM_PAGE_RESERVED, PMM_PAGE_FREE_HEAD,
+	PMM_PAGE_FREE_TAIL, PMM_PAGE_ALLOC_HEAD, PMM_PAGE_ALLOC_TAIL };
 
-typedef struct _lb_mem_rgn_ {
-	uint64_t base;
-	uint64_t size;
-	uint64_t pageCount;
-} LBMemoryRegion;
-/**
-* @brief AuPmmngrInitBitmap -- Initialize the Ram bitmap with
-* all zeros
-* @param BitmapSize -- total bitmap size
-* @param Buffer -- Pointer to bitmap buffer
-*/
-void AuPmmngrInitBitmap(size_t BSize, void* Buffer) {
-	BitmapBuffer = (uint8_t*)Buffer;
-	memset(BitmapBuffer, 0, BSize);
-	_BitmapSize = BSize;
+typedef struct PmmPageDesc {
+	uint64_t next, prev, owner;
+	int64_t backing_block;
+	uint32_t requested_pages, validation_epoch;
+	uint16_t refcount;
+	uint8_t order, state, page_type, padding[3];
+} PmmPageDesc;
+typedef struct PmmRange { uint64_t first, last; } PmmRange;
+typedef struct LBMemoryRegion { uint64_t base, size, pageCount; } LBMemoryRegion;
+
+static PmmPageDesc* page_desc;
+static uint64_t page_desc_phys, direct_map_base, direct_map_size, total_pages;
+static uint64_t free_head[PMM_MAX_ORDER + 1];
+static AuPmmStats pmm_stats;
+static Spinlock* pmm_lock;
+static PmmRange usable[PMM_MAX_REGIONS], reserved[PMM_MAX_RESERVATIONS];
+static uint32_t usable_count, reserved_count, validation_epoch;
+static bool higher_half;
+
+static inline uint64_t align_up(uint64_t v, uint64_t a) { return (v + a - 1) & ~(a - 1); }
+static inline bool valid_page(uint64_t p) { return p < total_pages; }
+static inline bool power_of_two(uint64_t v) { return v && !(v & (v - 1)); }
+static inline void lock(void) { if (pmm_lock) AuAcquireSpinlock(pmm_lock); }
+static inline void unlock(void) { if (pmm_lock) AuReleaseSpinlock(pmm_lock); }
+
+static void fatal(const char* reason, uint64_t page, uint64_t detail) {
+	AuTextOut("[pmm]: FATAL %s page=%x detail=%x\r\n", reason,
+		page == PMM_NO_PAGE ? PMM_NO_PAGE : page << PAGE_SHIFT, detail);
+	for (;;) asm volatile("wfe");
 }
 
-bool AuPmmngrBitmapCheck(uint64_t index) {
-	if (index >= _BitmapSize * 8)
-		return false;
-	size_t ByteIndex = index / 8;
-	uint8_t BitIndex = index % 8;
-	uint8_t BitIndexer = 0x80 >> BitIndex;
+static void add_reservation(uint64_t first, uint64_t last) {
+	if (first >= last) return;
+	if (reserved_count == PMM_MAX_RESERVATIONS) fatal("reservation table full", first, last);
+	reserved[reserved_count++] = (PmmRange){ first, last };
+}
 
-	if ((BitmapBuffer[ByteIndex] & BitIndexer) > 0) {
-		return true;
+static void normalize(PmmRange* ranges, uint32_t* count) {
+	for (uint32_t i = 1; i < *count; ++i) {
+		PmmRange key = ranges[i]; uint32_t j = i;
+		while (j && ranges[j - 1].first > key.first) { ranges[j] = ranges[j - 1]; --j; }
+		ranges[j] = key;
 	}
-	if (debugon)
-		AuTextOut("Bit -> %d Index -> %d \n", (BitmapBuffer[ByteIndex] & BitIndexer), index);
-	//return ((Buffer[ByteIndex] & BitIndexer) != 0);
+	uint32_t out = 0;
+	for (uint32_t i = 0; i < *count; ++i) {
+		if (out && ranges[i].first <= ranges[out - 1].last) {
+			if (ranges[i].last > ranges[out - 1].last) ranges[out - 1].last = ranges[i].last;
+		} else ranges[out++] = ranges[i];
+	}
+	*count = out;
+}
+
+static uint8_t floor_order(uint64_t pages) {
+	uint8_t order = 0; while (pages > 1) { pages >>= 1; ++order; } return order;
+}
+static uint8_t order_for_pages(uint64_t pages) {
+	uint8_t order = 0; uint64_t size = 1;
+	while (size < pages && order < PMM_MAX_ORDER) { size <<= 1; ++order; }
+	return order;
+}
+
+static void mark_free_block(uint64_t head, uint8_t order) {
+	uint64_t count = 1ULL << order;
+	if (!valid_page(head) || count > total_pages - head) fatal("free block outside metadata", head, order);
+	for (uint64_t i = 0; i < count; ++i) {
+		PmmPageDesc* d = &page_desc[head + i];
+		d->next = d->prev = PMM_NO_PAGE; d->owner = head; d->requested_pages = 0;
+		d->refcount = 0; d->order = order;
+		d->state = i ? PMM_PAGE_FREE_TAIL : PMM_PAGE_FREE_HEAD; d->page_type = 0;
+	}
+}
+
+static void list_insert(uint64_t head, uint8_t order) {
+	PmmPageDesc* d = &page_desc[head];
+	if (d->state != PMM_PAGE_FREE_HEAD || d->owner != head || d->order != order)
+		fatal("invalid free-list insertion", head, order);
+	d->prev = PMM_NO_PAGE; d->next = free_head[order];
+	if (d->next != PMM_NO_PAGE) {
+		if (!valid_page(d->next)) fatal("bad free-list next", head, d->next);
+		page_desc[d->next].prev = head;
+	}
+	free_head[order] = head;
+}
+
+static void list_remove(uint64_t head, uint8_t order) {
+	PmmPageDesc* d = &page_desc[head];
+	if (d->state != PMM_PAGE_FREE_HEAD || d->owner != head || d->order != order)
+		fatal("invalid free-list removal", head, order);
+	if (d->prev == PMM_NO_PAGE) {
+		if (free_head[order] != head) fatal("free-list head mismatch", head, order);
+		free_head[order] = d->next;
+	} else {
+		if (!valid_page(d->prev) || page_desc[d->prev].next != head) fatal("broken prev", head, d->prev);
+		page_desc[d->prev].next = d->next;
+	}
+	if (d->next != PMM_NO_PAGE) {
+		if (!valid_page(d->next) || page_desc[d->next].prev != head) fatal("broken next", head, d->next);
+		page_desc[d->next].prev = d->prev;
+	}
+	d->next = d->prev = PMM_NO_PAGE;
+}
+
+static void add_free_range(uint64_t first, uint64_t last) {
+	while (first < last) {
+		uint8_t order = floor_order(last - first);
+		while (order && (first & ((1ULL << order) - 1))) --order;
+		mark_free_block(first, order); list_insert(first, order); first += 1ULL << order;
+	}
+}
+
+static void add_usable_minus_reservations(uint64_t first, uint64_t last) {
+	uint64_t current = first;
+	for (uint32_t i = 0; i < reserved_count && current < last; ++i) {
+		if (reserved[i].last <= current) continue;
+		if (reserved[i].first >= last) break;
+		if (reserved[i].first > current)
+			add_free_range(current, reserved[i].first < last ? reserved[i].first : last);
+		if (reserved[i].last > current) current = reserved[i].last;
+	}
+	if (current < last) add_free_range(current, last);
+}
+
+static void mark_allocated(uint64_t head, uint8_t order, uint32_t requested, uint8_t type) {
+	uint64_t count = 1ULL << order;
+	for (uint64_t i = 0; i < count; ++i) {
+		PmmPageDesc* d = &page_desc[head + i];
+		d->next = d->prev = PMM_NO_PAGE; d->owner = head; d->backing_block = -1;
+		d->requested_pages = 0; d->refcount = 1; d->order = order;
+		d->state = i ? PMM_PAGE_ALLOC_TAIL : PMM_PAGE_ALLOC_HEAD; d->page_type = type;
+	}
+	page_desc[head].requested_pages = requested;
+}
+
+static uint64_t take_block(uint8_t wanted, uint32_t alignment, uint64_t ceiling) {
+	uint8_t aorder = order_for_pages(alignment);
+	uint8_t start = wanted > aorder ? wanted : aorder;
+	for (uint8_t order = start; order <= PMM_MAX_ORDER; ++order) {
+		for (uint64_t head = free_head[order]; head != PMM_NO_PAGE; head = page_desc[head].next) {
+			uint64_t count = 1ULL << wanted;
+			uint64_t end_phys = ((head + count) << PAGE_SHIFT) - 1;
+			if (ceiling && end_phys > ceiling) continue;
+			list_remove(head, order);
+			while (order > wanted) {
+				--order;
+				uint64_t right = head + (1ULL << order);
+				mark_free_block(right, order); list_insert(right, order); mark_free_block(head, order);
+			}
+			return head;
+		}
+	}
+	return PMM_NO_PAGE;
+}
+
+static void release_block(uint64_t head, uint8_t order) {
+	mark_free_block(head, order);
+	while (order < PMM_MAX_ORDER) {
+		uint64_t buddy = head ^ (1ULL << order);
+		if (!valid_page(buddy)) break;
+		PmmPageDesc* d = &page_desc[buddy];
+		if (d->state != PMM_PAGE_FREE_HEAD || d->owner != buddy || d->order != order) break;
+		list_remove(buddy, order); if (buddy < head) head = buddy; ++order; mark_free_block(head, order);
+	}
+	list_insert(head, order);
+}
+
+static void collect_uefi(KERNEL_BOOT_INFO* info, uint64_t* highest) {
+	uint64_t entries = info->descriptor_size ? info->mem_map_size / info->descriptor_size : 0;
+	for (uint64_t i = 0; i < entries; ++i) {
+		EFI_MEMORY_DESCRIPTOR* m = (EFI_MEMORY_DESCRIPTOR*)((uint64_t)info->map + i * info->descriptor_size);
+		uint64_t end = m->phys_start + (m->num_pages << PAGE_SHIFT);
+		if (m->type <= 7 && end > *highest) *highest = end;
+		if (m->type == 7 && m->num_pages) {
+			if (usable_count == PMM_MAX_REGIONS) fatal("usable table full", i, entries);
+			usable[usable_count++] = (PmmRange){ m->phys_start >> PAGE_SHIFT, end >> PAGE_SHIFT };
+		}
+	}
+}
+
+static void collect_littleboot(KERNEL_BOOT_INFO* info, uint64_t* highest) {
+	AuLittleBootProtocol* lb = (AuLittleBootProtocol*)info->driver_entry1;
+	if (!lb) fatal("missing LittleBoot protocol", PMM_NO_PAGE, 0);
+	LBMemoryRegion* regions = (LBMemoryRegion*)lb->usable_memory_map;
+	for (uint64_t i = 0; i < (uint64_t)lb->usable_region_count; ++i) {
+		if (usable_count == PMM_MAX_REGIONS) fatal("usable table full", i, lb->usable_region_count);
+		uint64_t first = regions[i].base >> PAGE_SHIFT, last = first + regions[i].pageCount;
+		usable[usable_count++] = (PmmRange){ first, last };
+		if ((last << PAGE_SHIFT) > *highest) *highest = last << PAGE_SHIFT;
+	}
+	add_reservation(0, 0x100000 >> PAGE_SHIFT);
+	add_reservation(lb->device_tree_base >> PAGE_SHIFT, align_up(lb->device_tree_end, PAGE_SIZE) >> PAGE_SHIFT);
+	add_reservation(lb->initrd_start >> PAGE_SHIFT, align_up(lb->initrd_end, PAGE_SIZE) >> PAGE_SHIFT);
+	add_reservation(lb->littleBootStart >> PAGE_SHIFT, align_up(lb->littleBootEnd, PAGE_SIZE) >> PAGE_SHIFT);
+}
+
+static bool find_metadata(uint64_t pages, uint64_t* result) {
+	for (uint32_t i = 0; i < usable_count; ++i) {
+		uint64_t current = usable[i].first;
+		for (uint32_t j = 0; j < reserved_count && current < usable[i].last; ++j) {
+			if (reserved[j].last <= current) continue;
+			if (reserved[j].first >= usable[i].last) break;
+			if (reserved[j].first > current && reserved[j].first - current >= pages) {
+				*result = current; return true;
+			}
+			if (reserved[j].last > current) current = reserved[j].last;
+		}
+		if (usable[i].last > current && usable[i].last - current >= pages) {
+			*result = current; return true;
+		}
+	}
 	return false;
 }
 
-bool AuPmmngrBitmapSet(uint64_t index, bool value) {
-	if (index >= _BitmapSize * 8)
-		return false;
-	size_t ByteIndex = index / 8;
-	uint8_t BitIndex = index % 8;
-	uint8_t BitIndexer = 0x80 >> BitIndex;
-
-	BitmapBuffer[ByteIndex] &= ~BitIndexer;
-	if (value)
-		BitmapBuffer[ByteIndex] |= BitIndexer;
-	return true;
-}
-
-/**
-* @brief AuPmmngrLockPage -- Lock a given page
-* @param Address -- Pointer to page
-*/
-void AuPmmngrLockPage(uint64_t Address) {
-	uint64_t Index = Address >> PAGE_SHIFT;
-	if (AuPmmngrBitmapCheck(Index))
-		return;
-	if (AuPmmngrBitmapSet(Index, true)) {
-		_FreeMemory--;
-		_ReservedMemory++;
+static void recount(void) {
+	memset(&pmm_stats, 0, sizeof(pmm_stats));
+	for (uint64_t p = 0; p < total_pages; ++p) {
+		switch (page_desc[p].state) {
+		case PMM_PAGE_UNMANAGED: ++pmm_stats.unmanaged_pages; break;
+		case PMM_PAGE_RESERVED: ++pmm_stats.reserved_pages; ++pmm_stats.managed_pages; break;
+		case PMM_PAGE_FREE_HEAD: case PMM_PAGE_FREE_TAIL:
+			++pmm_stats.free_pages; ++pmm_stats.managed_pages; break;
+		case PMM_PAGE_ALLOC_HEAD: case PMM_PAGE_ALLOC_TAIL:
+			++pmm_stats.allocated_pages; ++pmm_stats.managed_pages; break;
+		default: fatal("unknown descriptor state", p, page_desc[p].state);
+		}
 	}
 }
 
-/**
-* @brief AuPmmngrLockPage -- locks a set of pages
-* @param Address -- Starting address of the first page
-* @param Size -- Size of the set
-*/
-void AuPmmngrLockPages(void* Address, size_t Size) {
-	uint64_t addr = (uint64_t)Address;
-	for (size_t i = 0; i < Size; i++) {
-		AuPmmngrLockPage(addr + i * 4096);
+bool AuPmmngrValidate(void) {
+	bool ok = true; lock();
+	if (++validation_epoch == 0) {
+		for (uint64_t p = 0; p < total_pages; ++p) page_desc[p].validation_epoch = 0;
+		validation_epoch = 1;
 	}
+	uint64_t listed = 0;
+	for (uint8_t order = 0; ok && order <= PMM_MAX_ORDER; ++order) {
+		uint64_t previous = PMM_NO_PAGE;
+		for (uint64_t head = free_head[order]; head != PMM_NO_PAGE; head = page_desc[head].next) {
+			if (!valid_page(head)) { ok = false; break; }
+			PmmPageDesc* d = &page_desc[head];
+			if (d->validation_epoch == validation_epoch || d->state != PMM_PAGE_FREE_HEAD ||
+				d->owner != head || d->order != order || d->prev != previous ||
+				(head & ((1ULL << order) - 1))) { ok = false; break; }
+			d->validation_epoch = validation_epoch; listed += 1ULL << order; previous = head;
+		}
+	}
+	uint64_t managed = 0, free = 0, allocated = 0, res = 0, unmanaged = 0;
+	for (uint64_t p = 0; ok && p < total_pages; ++p) {
+		PmmPageDesc* d = &page_desc[p];
+		switch (d->state) {
+		case PMM_PAGE_UNMANAGED: ++unmanaged; break;
+		case PMM_PAGE_RESERVED: ++res; ++managed; break;
+		case PMM_PAGE_FREE_HEAD:
+			if (d->owner != p || d->validation_epoch != validation_epoch) ok = false;
+			++free; ++managed; break;
+		case PMM_PAGE_FREE_TAIL:
+			if (!valid_page(d->owner) || page_desc[d->owner].state != PMM_PAGE_FREE_HEAD ||
+				page_desc[d->owner].order != d->order) ok = false;
+			++free; ++managed; break;
+		case PMM_PAGE_ALLOC_HEAD:
+			if (d->owner != p || !d->requested_pages || !d->refcount) ok = false;
+			++allocated; ++managed; break;
+		case PMM_PAGE_ALLOC_TAIL:
+			if (!valid_page(d->owner) || page_desc[d->owner].state != PMM_PAGE_ALLOC_HEAD ||
+				page_desc[d->owner].order != d->order) ok = false;
+			++allocated; ++managed; break;
+		default: ok = false; break;
+		}
+	}
+	if (listed != free || managed != pmm_stats.managed_pages || free != pmm_stats.free_pages ||
+		allocated != pmm_stats.allocated_pages || res != pmm_stats.reserved_pages ||
+		unmanaged != pmm_stats.unmanaged_pages || free + allocated + res != managed) ok = false;
+	unlock(); return ok;
 }
 
-/**
-* @brief AuPmmngrUnreservePage -- Marks a page as free
-* @param Address -- Pointer to the page
-*/
-void AuPmmngrUnreservePage(void* Address) {
-	uint64_t Index = (uint64_t)Address / 4096;
-	if (AuPmmngrBitmapCheck(Index) == false)
-		return;
-	if (AuPmmngrBitmapSet(Index, false)) {
-		_FreeMemory++;
-		_ReservedMemory--;
-		if (_RamBitmapIndex > Index)
-			_RamBitmapIndex = Index;
+static void boot_self_test(void) {
+	AuPmmStats before, after; uint64_t singles[384], runs[6];
+	const uint32_t sizes[6] = { 2, 3, 4, 17, 128, 256 };
+	AuPmmngrGetStats(&before);
+	for (uint32_t i = 0; i < 384; ++i) {
+		singles[i] = AuPmmngrAllocPage(AURORA_PAGE_KERNEL);
+		if (singles[i] == PMM_INVALID_PHYS) fatal("self-test order-0", i, 0);
+		for (uint32_t j = 0; j < i; ++j) if (singles[j] == singles[i]) fatal("self-test duplicate", i, singles[i]);
 	}
+	if (!AuPmmngrRetainPage(singles[0]) || AuPmmngrPageRefcount(singles[0]) != 2 ||
+		!AuPmmngrReleasePage(singles[0]) || AuPmmngrPageRefcount(singles[0]) != 1)
+		fatal("self-test refcount", singles[0] >> PAGE_SHIFT, 0);
+	for (uint32_t i = 0; i < 6; ++i) {
+		runs[i] = AuPmmngrAllocPages(sizes[i], i == 5 ? 64 : 1, 0, AURORA_PAGE_KERNEL);
+		if (runs[i] == PMM_INVALID_PHYS) fatal("self-test compound", i, sizes[i]);
+	}
+	if ((runs[5] >> PAGE_SHIFT) & 63) fatal("self-test alignment", runs[5] >> PAGE_SHIFT, 64);
+	for (uint32_t i = 0; i < 384; i += 2) if (!AuPmmngrReleasePage(singles[i])) fatal("self-test free", i, singles[i]);
+	for (uint32_t i = 0; i < 6; ++i) if (!AuPmmngrReleasePages(runs[i])) fatal("self-test run free", i, runs[i]);
+	for (uint32_t i = 1; i < 384; i += 2) if (!AuPmmngrReleasePage(singles[i])) fatal("self-test free", i, singles[i]);
+	AuPmmngrGetStats(&after);
+	if (memcmp(&before, &after, sizeof(before)) || !AuPmmngrValidate())
+		fatal("self-test restore", PMM_NO_PAGE, after.free_pages);
+	AuTextOut("[pmm]: boot self-test passed\r\n");
 }
 
-/**
-* @brief AuPmmngrInitialise -- initialise the physical memory
-* manager
-* @param info -- Pointer to kernel boot info structure
-*/
 void AuPmmngrInitialize(KERNEL_BOOT_INFO* info) {
-	/*
-	 * TODO: UEFI has a good memory map, which describes which areas are usable and
-	 * which are reserved, but for LittleBoot based memory map takes the starting of usable
-	 * ram directly, and start sectioning the ram into usable and unusable area, below
-	 * the starting of usable area, those areas are for hardware mmio reserved. Basically
-	 * in this Pmmngr, it only takes the starting area for examplae, 0x40000000 in QEMU, and 
-	 * search a suitable bitmap area from that area, and mark the usable area from bitmap_area + 
-	 * bitmapsize, which is not a design approach, the design should be make the usable area
-	 * from 0x0 of RAM and reserve all the Hardware mmio reserved memories, the usable_area
-	 * marker will automatically come to 0x40000000
-	 */
-	debugon = 0;
-	_FreeMemory = 0;
-	_BitmapSize = 0;
-	_TotalRam = 0;
-	_RamBitmapIndex = 0;
-	BitmapBuffer = 0;
-	uint64_t MemMapEntries = 0;
-	void* BitmapArea = 0;
-	bool print = 0;
-
-	uint64_t HighestAddress = 0;
-
-	if (info->boot_type != BOOT_LITTLEBOOT_ARM64) {
-		MemMapEntries = info->mem_map_size / info->descriptor_size;
-		/* Scan a suitable area for the bitmap */
-		for (size_t i = 0; i < MemMapEntries; i++) {
-			EFI_MEMORY_DESCRIPTOR* EfiMem =
-				(EFI_MEMORY_DESCRIPTOR*)((uint64_t)info->map + i * info->descriptor_size);
-
-			uint64_t end_addr = EfiMem->phys_start + (EfiMem->num_pages * 4096);
-			if (end_addr > HighestAddress) {
-				HighestAddress = end_addr;
-			}
-
-			if (EfiMem->type == 7) {
-				_TotalRam += EfiMem->num_pages;
-				if (((EfiMem->num_pages * 4096) > 0x1F0000) && BitmapArea == 0) {
-					if ((EfiMem->phys_start & (4096 - 1)) == 0) {
-						if (!print)
-							AuTextOut("RAM Starts at -> %x end -> %x \n",
-									  EfiMem->phys_start,
-									  (EfiMem->phys_start + (EfiMem->num_pages * 4096)));
-						BitmapArea =
-							(void*)EfiMem->phys_start; // ((EfiMem->phys_start + 0xFFF) & ~0xFFF);
-						print = 0;
-					}
-				}
-			}
-			if (EfiMem->type == 1) {
-				_TotalRam += EfiMem->num_pages;
-			}
-			if (EfiMem->type == 2) {
-				_TotalRam += EfiMem->num_pages;
-			}
-			if (EfiMem->type == 3) {
-				_TotalRam += EfiMem->num_pages;
-			}
-
-			if (EfiMem->type == 4) {
-				_TotalRam += EfiMem->num_pages;
-			}
-		}
-	} else {
-		AuLittleBootProtocol* lb = (AuLittleBootProtocol*)info->driver_entry1;
-		LBMemoryRegion* memRegn = (LBMemoryRegion*)lb->usable_memory_map;
-
-		if (!lb) {
-			AuTextOut("[aurora]:Booting from non-UEFI boot environment but missing LittleBoot "
-					  "protocol \r\n");
-			AuTextOut("[aurora]:Unable to continue Kernel initialization \r\n");
-			for (;;)
-				;
-		}
-		for (size_t i = 0; i < lb->usable_region_count; i++) {
-			uint64_t base = memRegn[i].base;
-			uint64_t numPages = memRegn[i].pageCount;
-			uint64_t end_addr = base + (numPages * 4096);
-			if (end_addr > HighestAddress) {
-				HighestAddress = end_addr;
-			}
-			if (((numPages * 4096) > 0x1F0000) && BitmapArea == 0) {
-				BitmapArea = (void*)base;
-			}
-			AuTextOut("[aurora]: Usable memory Base : %x , PageCount : %d \r\n", base, numPages);
-		}
-		_TotalRam = lb->numberOfPages;
-		AuTextOut("Total Ram : %d Pages \r\n", _TotalRam);
-		AuTextOut("Memory Start : %x, Memory End : %x \r\n", lb->physicalStart, lb->physicalEnd);
+	uint64_t highest = 0, metadata_start = 0;
+	usable_count = reserved_count = validation_epoch = 0; higher_half = false;
+	direct_map_base = info->physical_direct_map_base; direct_map_size = info->physical_direct_map_size;
+	pmm_lock = AuCreateSpinlock(true); if (!pmm_lock) fatal("no early spinlock", PMM_NO_PAGE, 0);
+	for (uint8_t order = 0; order <= PMM_MAX_ORDER; ++order) free_head[order] = PMM_NO_PAGE;
+	if (info->boot_type == BOOT_LITTLEBOOT_ARM64) collect_littleboot(info, &highest); else collect_uefi(info, &highest);
+	normalize(usable, &usable_count); if (!usable_count || !highest) fatal("no usable RAM", PMM_NO_PAGE, 0);
+	add_reservation(0, 0x100000 >> PAGE_SHIFT);
+	uint64_t* stack = (uint64_t*)info->allocated_stack;
+	for (uint64_t i = 0; stack && i < info->reserved_mem_count; ++i) {
+		uint64_t address = *--stack; add_reservation(address >> PAGE_SHIFT, (address >> PAGE_SHIFT) + 1);
 	}
-
-	//AuPmmngrEarlyVMSetup(info);
-
-	_FreeMemory = _TotalRam;
-	AuTextOut("Total RAM : %x \r\n", (_TotalRam * 0x1000));
-	AuTextOut("Highest Address : %x \r\n", HighestAddress);
-
-	uint64_t TotalPagesCount = HighestAddress / 4096;
-	uint64_t BitmapSize = (TotalPagesCount / 8) + 1; // (_TotalRam * 4096) / 4096 / 8 + 1;
-	uint64_t page_desc_addr = (uint64_t)BitmapArea + BitmapSize;
-	page_desc_addr = ALIGN_UP(page_desc_addr, 64);
-	page_desc = (AuPageDesc*)page_desc_addr;
-	total_page_desc_count = TotalPagesCount;
-	size_t page_desc_len = total_page_desc_count * sizeof(AuPageDesc);
-	UsablePhysicalMemory = (uint64_t)page_desc_addr + page_desc_len;
-	UsablePhysicalMemory = (UsablePhysicalMemory + (PAGE_SIZE - 1)) & ~(uint64_t)(PAGE_SIZE - 1);
-
-	AuTextOut("Usable RAM Start : %x, TotalRAM : %x \r\n", UsablePhysicalMemory, _TotalRam);
-	AuTextOut("LastPage : %x \r\n", (_TotalRam * 4096));
-
-	/* now initialise the bitmap */
-	AuPmmngrInitBitmap(BitmapSize, BitmapArea);
-	AuTextOut("Bitmap Size : %x %d \r\n", BitmapSize, BitmapSize);
-	//AuPmmngrLockPages((void*)BitmapArea, BitmapSize);
-	//AuPmmngrLockPages((void*)page_desc_addr, total_page_desc_count);
-
-	if (info->boot_type != BOOT_LITTLEBOOT_ARM64) {
-		for (size_t i = 0; i < MemMapEntries; i++) {
-			EFI_MEMORY_DESCRIPTOR* EfiMem =
-				(EFI_MEMORY_DESCRIPTOR*)((uint64_t)info->map + i * info->descriptor_size);
-			//_TotalRam += EfiMem->num_pages;
-			if (EfiMem->type != 7) {
-				uint64_t PhysStart = EfiMem->phys_start;
-				for (size_t j = 0; j < EfiMem->num_pages; j++) {
-					AuPmmngrLockPage(PhysStart + j * 4096);
-				}
-			}
-		}
+	normalize(reserved, &reserved_count); total_pages = align_up(highest, PAGE_SIZE) >> PAGE_SHIFT;
+	uint64_t metadata_pages = align_up(total_pages * sizeof(PmmPageDesc), PAGE_SIZE) >> PAGE_SHIFT;
+	if (!find_metadata(metadata_pages, &metadata_start)) fatal("no RAM for descriptors", PMM_NO_PAGE, metadata_pages);
+	add_reservation(metadata_start, metadata_start + metadata_pages); normalize(reserved, &reserved_count);
+	page_desc_phys = metadata_start << PAGE_SHIFT;
+	if (direct_map_size) {
+		if (page_desc_phys + metadata_pages * PAGE_SIZE > direct_map_size)
+			fatal("descriptors outside direct map", metadata_start, metadata_pages);
+		higher_half = true; page_desc = (PmmPageDesc*)(direct_map_base + page_desc_phys);
+	} else page_desc = (PmmPageDesc*)page_desc_phys;
+	memset(page_desc, 0, metadata_pages * PAGE_SIZE);
+	for (uint64_t p = 0; p < total_pages; ++p) {
+		page_desc[p].next = page_desc[p].prev = page_desc[p].owner = PMM_NO_PAGE;
+		page_desc[p].backing_block = -1; page_desc[p].state = PMM_PAGE_UNMANAGED;
 	}
-
-	/* Lock addresses below 1MiB mark */
-	for (size_t i = 0; i < (1 * 1024 * 1024) / 4096; i++)
-		AuPmmngrLockPage(i * 4096);
-
-	uint32_t AllocCount = info->reserved_mem_count;
-	uint64_t* AllocStack = (uint64_t*)info->allocated_stack;
-	while (AllocCount) {
-		uint64_t Address = *AllocStack--;
-		AuPmmngrLockPage(Address);
-		AllocCount--;
-	}
-
-	for (uint64_t i = 0; i < (UsablePhysicalMemory >> PAGE_SHIFT); i++) {
-		AuPmmngrLockPage(i * PAGE_SIZE);
-	}
-	_RamBitmapIndex = UsablePhysicalMemory >> PAGE_SHIFT;
-
-	/* need more reservation of memory allocated by initrd and others*/
-	if (info->boot_type == BOOT_LITTLEBOOT_ARM64) {
-		/* reserving DTB area and Kernel INITRD area */
-		AuTextOut("[aurora]: Reserving LittleBoot data \r\n");
-		uint64_t pageCount = 0;
-		AuLittleBootProtocol* lb = (AuLittleBootProtocol*)info->driver_entry1;
-		uint64_t dtb_start = lb->device_tree_base;
-		uint64_t dtb_end = lb->device_tree_end;
-		dtb_end = (dtb_end + 0x1000 - 1) & ~(0x1000 - 1);
-
-		pageCount = (dtb_end - dtb_start) / 0x1000;
-
-		for (int i = 0; i < pageCount; i++) {
-			uint64_t addr = dtb_start + (uint64_t)i * 0x1000;
-			AuPmmngrLockPage(addr);
-		}
-
-		uint64_t initrdStart = lb->initrd_start;
-		uint64_t initrdEnd = lb->initrd_end;
-		initrdEnd = (initrdEnd + 0x1000 - 1) & ~(0x1000 - 1);
-		pageCount = (initrdEnd - initrdStart) / 0x1000;
-		for (int i = 0; i < pageCount; i++) {
-			uint64_t addr = initrdStart + (uint64_t)i * 0x1000;
-			AuPmmngrLockPage(addr);
-		}
-
-		uint64_t lbStart = lb->littleBootStart;
-		uint64_t lbEnd = lb->littleBootEnd;
-		lbEnd = (lbEnd + 0x1000 - 1) & ~(0x1000 - 1);
-		pageCount = (lbEnd - lbStart) / 0x1000;
-
-		for (int i = 0; i < pageCount; i++) {
-			uint64_t addr = lbStart + (uint64_t)i * 0x1000;
-			AuPmmngrLockPage(addr);
-		}
-		AuTextOut("[aurora]: Pmmngr locked LittleBoot reserved memory\r\n");
-	}
+	for (uint32_t i = 0; i < usable_count; ++i)
+		for (uint64_t p = usable[i].first; p < usable[i].last; ++p) page_desc[p].state = PMM_PAGE_RESERVED;
+	for (uint32_t i = 0; i < usable_count; ++i) add_usable_minus_reservations(usable[i].first, usable[i].last);
+	recount(); if (!AuPmmngrValidate()) fatal("initial validation", PMM_NO_PAGE, 0);
+	AuTextOut("[pmm]: buddy online, free=%d pages reserved=%d pages\r\n", pmm_stats.free_pages, pmm_stats.reserved_pages);
+	boot_self_test();
 }
+
+uint64_t AuPmmngrAllocPages(uint32_t pages, uint32_t alignment, uint64_t ceiling, uint8_t type) {
+	if (!pages) return PMM_INVALID_PHYS; if (!alignment) alignment = 1;
+	if (!power_of_two(alignment)) return PMM_INVALID_PHYS;
+	uint8_t order = order_for_pages(pages); if (order > PMM_MAX_ORDER) return PMM_INVALID_PHYS;
+	lock(); uint64_t head = take_block(order, alignment, ceiling);
+	if (head != PMM_NO_PAGE) {
+		uint64_t count = 1ULL << order; mark_allocated(head, order, pages, type ? type : AURORA_PAGE_NORMAL);
+		pmm_stats.free_pages -= count; pmm_stats.allocated_pages += count;
+	}
+	unlock(); return head == PMM_NO_PAGE ? PMM_INVALID_PHYS : head << PAGE_SHIFT;
+}
+
+uint64_t AuPmmngrAllocPage(uint8_t type) { return AuPmmngrAllocPages(1, 1, 0, type); }
+
+bool AuPmmngrReleasePage(uint64_t phys) {
+	if ((phys & (PAGE_SIZE - 1)) || !valid_page(phys >> PAGE_SHIFT)) return false;
+	uint64_t page = phys >> PAGE_SHIFT; bool released = false; lock(); PmmPageDesc* d = &page_desc[page];
+	if (d->state == PMM_PAGE_ALLOC_HEAD && d->owner == page && d->order == 0 && d->requested_pages == 1 && d->refcount) {
+		if (--d->refcount == 0) { release_block(page, 0); ++pmm_stats.free_pages; --pmm_stats.allocated_pages; }
+		released = true;
+	}
+	unlock(); if (released) dsb_ish(); return released;
+}
+
+bool AuPmmngrReleasePages(uint64_t phys) {
+	if ((phys & (PAGE_SIZE - 1)) || !valid_page(phys >> PAGE_SHIFT)) return false;
+	uint64_t head = phys >> PAGE_SHIFT; bool released = false; lock(); PmmPageDesc* d = &page_desc[head];
+	if (d->state == PMM_PAGE_ALLOC_HEAD && d->owner == head && d->requested_pages) {
+		uint64_t count = 1ULL << d->order; released = true;
+		for (uint64_t i = 0; i < count; ++i) if (page_desc[head + i].refcount != 1) { released = false; break; }
+		if (released) { uint8_t order = d->order; release_block(head, order); pmm_stats.free_pages += count; pmm_stats.allocated_pages -= count; }
+	}
+	unlock(); if (released) dsb_ish(); return released;
+}
+
+bool AuPmmngrRetainPage(uint64_t phys) {
+	if ((phys & (PAGE_SIZE - 1)) || !valid_page(phys >> PAGE_SHIFT)) return false;
+	uint64_t page = phys >> PAGE_SHIFT; bool retained = false; lock(); PmmPageDesc* d = &page_desc[page];
+	if (d->state == PMM_PAGE_ALLOC_HEAD && d->owner == page && d->order == 0 && d->refcount != UINT16_MAX) {
+		++d->refcount; retained = true;
+	}
+	unlock(); return retained;
+}
+
+uint16_t AuPmmngrPageRefcount(uint64_t phys) {
+	if ((phys & (PAGE_SIZE - 1)) || !valid_page(phys >> PAGE_SHIFT)) return 0;
+	lock(); PmmPageDesc* d = &page_desc[phys >> PAGE_SHIFT];
+	uint16_t refs = d->state == PMM_PAGE_ALLOC_HEAD && d->order == 0 ? d->refcount : 0; unlock(); return refs;
+}
+
+bool AuPmmngrSetBackingBlock(uint64_t phys, int64_t block) {
+	if ((phys & (PAGE_SIZE - 1)) || !valid_page(phys >> PAGE_SHIFT)) return false;
+	bool set = false; lock(); PmmPageDesc* d = &page_desc[phys >> PAGE_SHIFT];
+	if (d->state == PMM_PAGE_ALLOC_HEAD && d->order == 0) { d->backing_block = block; set = true; }
+	unlock(); return set;
+}
+
+int64_t AuPmmngrGetBackingBlock(uint64_t phys) {
+	if ((phys & (PAGE_SIZE - 1)) || !valid_page(phys >> PAGE_SHIFT)) return -1;
+	int64_t block = -1; lock(); PmmPageDesc* d = &page_desc[phys >> PAGE_SHIFT];
+	if (d->state == PMM_PAGE_ALLOC_HEAD && d->order == 0) block = d->backing_block;
+	unlock(); return block;
+}
+
+void AuPmmngrGetStats(AuPmmStats* stats) { if (!stats) return; lock(); *stats = pmm_stats; unlock(); }
 
 bool AuPmmngrAllocCheck(uint64_t address) {
-	uint64_t addr = ((uint64_t)address - UsablePhysicalMemory);
-	uint64_t Index = (uint64_t)addr / 4096;
-	if (AuPmmngrBitmapCheck(Index) == true)
-		return true;
-	return false;
+	uint64_t page = address >> PAGE_SHIFT;
+	return valid_page(page) && (page_desc[page].state == PMM_PAGE_ALLOC_HEAD || page_desc[page].state == PMM_PAGE_ALLOC_TAIL);
 }
 
-/**
- * @brief AuPmmngrAlloc -- Allocate a single physical page
- * frame and return it to the caller
- */
-void* AuPmmngrAlloc() {
-	for (; _RamBitmapIndex < _BitmapSize * 8; _RamBitmapIndex++) {
-		//AuTextOut("  RamBitmap[%d] -> %d   ",_RamBitmapIndex, RamBitmap[_RamBitmapIndex]);
-		if (AuPmmngrBitmapCheck(_RamBitmapIndex))
-			continue;
-		AuPmmngrLockPage(_RamBitmapIndex * PAGE_SIZE);
-		_UsedMemory++;
-		uint64_t index = _RamBitmapIndex;
-		//UARTDebugOut("AuPmmngrAlloc: RamBitmapIndex : %d %x \n", _RamBitmapIndex, (UsablePhysicalMemory + (index * 4096)));
-		page_desc[index].refcount = 1;
-		page_desc[index].phys_addr = (index * PAGE_SIZE);
-		page_desc[index].diskblock = -1;
-		//	UARTDebugOut("Page desc : %x \r\n", &page_desc[(UsablePhysicalMemory + (index * PAGE_SIZE)) >> PAGE_SHIFT]);
-		return (void*)(index * PAGE_SIZE);
-	}
-	AuTextOut("Kernel Panic!!! No more physical memory \n");
-	for (;;)
-		;
+uint64_t P2V(uint64_t addr) { return higher_half ? direct_map_base + addr : addr; }
+uint64_t V2P(uint64_t addr) { return higher_half ? addr - direct_map_base : addr; }
+void AuPmmngrMoveHigher(void) {
+	if (higher_half) return; direct_map_base = PHYSICAL_MEM_BASE; higher_half = true;
+	page_desc = (PmmPageDesc*)P2V(page_desc_phys);
 }
-
-/**
- * @brief AuPmmngrAllocBlocks -- Allocate multiple physical page frames
- * and return the first page pointer to the caller
- * @param size -- Number of blocks to allocate
- */
-void* AuPmmngrAllocBlocks(int num) {
-	void* First = AuPmmngrAlloc();
-	//UARTDebugOut("AuPmmngrAllocBlocks: %x \n", First);
-	for (int i = 1; i < num; i++) {
-		void* p = AuPmmngrAlloc();
-		//UARTDebugOut("AuPmmngrAllocBlocks: %x \n", p);
-	}
-	return First;
-}
-
-/**
- * @brief AuPmmngrFree -- Free a physical page frame
- * @param Address -- Pointer to physical page
- */
-void AuPmmngrFree(void* Address) {
-	uint64_t ShiftAddr = (uint64_t)Address >> PAGE_SHIFT;
-	if (page_desc[ShiftAddr].refcount > 1) {
-		page_desc[ShiftAddr].refcount -= 1;
-		return;
-	}
-	uint64_t Index = ShiftAddr;
-	if (AuPmmngrBitmapCheck(Index) == false)
-		return;
-	if (AuPmmngrBitmapSet(Index, false)) {
-		//UARTDebugOut("Was not free actual address : %x\n", Address);
-		_FreeMemory++;
-		_UsedMemory--;
-		if (_RamBitmapIndex > Index) {
-			//UARTDebugOut("RAMIndex was to : %d. set to : %d\n", _RamBitmapIndex, Index);
-			_RamBitmapIndex = Index;
-		}
-	}
-	dsb_ish();
-}
-
-/**
- * @brief AuPmmngrFreeBlocks -- Free multiple page frames
- * @param Addr -- Address of the first page frame
- * @param Count -- Number of blocks to be freed
- */
-void AuPmmngrFreeBlocks(void* Addr, int Count) {
-	uint64_t Address = (uint64_t)Addr;
-	for (uint32_t i = 0; i < Count; i++) {
-		AuPmmngrFree((void*)Address);
-		Address += 0x1000;
-	}
-}
-
-/**
- * @brief P2V -- Physical to Virtual conversion
- * @param addr -- Address to convert
- */
-uint64_t P2V(uint64_t addr) {
-	if (_HigherHalf)
-		return (PHYSICAL_MEM_BASE + addr);
-	else
-		return addr;
-}
-
-/**
- * @brief V2P -- Virtual to Physical conversion
- * @param vaddr -- Address to convert
- */
-uint64_t V2P(uint64_t vaddr) {
-	if (_HigherHalf)
-		return (vaddr - PHYSICAL_MEM_BASE);
-	else
-		return vaddr;
-}
-
-/**
-* @brief AuPmmngrMoveHigher -- moves the kernel to higher half
-* of memory
-*/
-void AuPmmngrMoveHigher() {
-	_HigherHalf = true;
-	BitmapBuffer = (uint8_t*)P2V((uint64_t)BitmapBuffer);
-	page_desc = (AuPageDesc*)P2V((uint64_t)page_desc);
-}
-
-/**
- * @brief AuPmmngrGetFreeMem -- returns the total free amount
- * of RAM
- */
-uint64_t AuPmmngrGetFreeMem() {
-	return _FreeMemory;
-}
-
-/**
- * @brief AuPmmngrGetUsedMem -- return total used page count
- */
-uint64_t AuPmmngrGetUsedMem() {
-	return _UsedMemory;
-}
-
-/**
- * @brief AuPmmngrGetTotalMem -- returns the total amount of
- * RAM
- */
-uint64_t AuPmmngrGetTotalMem() {
-	return _TotalRam;
-}
-
-/**
- * @brief AuPmmngrAddRefcount -- increment reference count
- * of given page
- * @param physaddr -- Physical address to increase reference
- * count of
- * @param count -- number of count to increase
- */
-void AuPmmngrAddRefcount(uint64_t physaddr, uint16_t count) {
-	page_desc[physaddr >> PAGE_SHIFT].refcount += count;
-}
-
-/**
- * @brief AuPmmngrGetRefcount -- returns the number of 
- * reference count for given physical address
- * @param physaddr -- physical address to check for reference
- * count
- * @return number of reference count
- */
-uint16_t AuPmmngrGetRefcount(uint64_t physaddr) {
-	return page_desc[physaddr >> PAGE_SHIFT].refcount;
-}
-
-/**
- * @brief AuPmmngrGetPageDesc -- return the correct
- * page descriptor of given physical address
- * @param physaddr -- physical address number
- */
-AuPageDesc* AuPmmngrGetPageDesc(uint64_t physaddr) {
-	return &page_desc[physaddr >> PAGE_SHIFT];
-}
-
-/**
- * @brief AuPmmngrSetPageType -- set page type
- * @param physaddr -- Physical address to treat
- * @param flags -- type flags
- */
-void AuPmmngrSetPageType(uint64_t physaddr, uint8_t flags) {
-	/** check if page is kernel or dma, if yes then 
-	 * normal bit should be removed, because kernel
-	 * will treat kernel or dma pages differently
-	 */
-	if (flags & AURORA_PAGE_KERNEL)
-		flags &= ~AURORA_PAGE_NORMAL;
-	if (flags & AURORA_PAGE_DMA)
-		flags &= ~AURORA_PAGE_NORMAL;
-	page_desc[physaddr >> PAGE_SHIFT].page_type = flags;
-}
-
-void AuPmmngrDebugInfo() {
-	AuTextOut("Total ram page : %d --- %d GB \r\n", _TotalRam, (_TotalRam / 1024 / 1024 / 1024));
-	AuTextOut("UsablePhysical Start : %x \r\n", UsablePhysicalMemory);
+void AuPmmngrDebugInfo(void) {
+	AuPmmStats s; AuPmmngrGetStats(&s);
+	AuTextOut("[pmm]: managed=%d free=%d allocated=%d reserved=%d unmanaged=%d pages\r\n",
+		s.managed_pages, s.free_pages, s.allocated_pages, s.reserved_pages, s.unmanaged_pages);
 }

--- a/KernelAA64/Mm/shm.c
+++ b/KernelAA64/Mm/shm.c
@@ -125,7 +125,7 @@ int AuCreateSHM(AuProcess* proc, uint16_t key, size_t sz, uint8_t flags) {
 		shm->link_count = 0;
 		shm->frames = (uint64_t*)kmalloc(sizeof(uint64_t) * shm->num_frames);
 		for (int i = 0; i < shm->num_frames; i++)
-			shm->frames[i] = (uint64_t)AuPmmngrAlloc();
+			shm->frames[i] = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 
 		list_add(shm_list, shm);
 	}
@@ -153,7 +153,7 @@ void AuSHMDelete(AuSHM* shm) {
 	if (shm->link_count == 0) {
 		for (int i = 0; i < shm->num_frames; i++) {
 			size_t phys = shm->frames[i];
-			AuPmmngrFree((void*)phys);
+			AuPmmngrReleasePage((uint64_t)phys);
 		}
 
 		for (int j = 0; j <= shm_list->pointer; j++) {
@@ -303,7 +303,8 @@ void* AuSHMObtainMem(AuProcess* proc, uint16_t id, void* shmaddr, int shmflg) {
 			if (gap >= mem->num_frames * PAGE_SIZE) {
 				for (int j = 0; j < mem->num_frames; j++) {
 					size_t phys = mem->frames[j];
-					AuPmmngrAddRefcount(phys, 1);
+					if (!AuPmmngrRetainPage(phys))
+						return NULL;
 					AuMapPage(phys, last_addr + j * PAGE_SIZE, PTE_AP_RW_USER);
 					isb_flush();
 					dsb_ish();

--- a/KernelAA64/Mm/tlsf.c
+++ b/KernelAA64/Mm/tlsf.c
@@ -55,6 +55,12 @@ static inline int tlsf_ffs32(uint32_t word) {
 	return (int)__builtin_ffs((int)word) - 1;
 }
 
+static inline int tlsf_ffs64(uint64_t word) {
+	if (word == 0)
+		return -1;
+	return (int)__builtin_ffsll((long long)word) - 1;
+}
+
 /* ---- Block helpers ---- */
 
 static inline size_t blk_size(const block_header_t* hdr) {
@@ -119,7 +125,7 @@ static void tlsf_remove_free_block(tlsf_pool_t* pool, free_block_t* blk, int fl,
 	if (pool->blocks[fl][sl] == NULL) {
 		pool->sl_bitmap[fl] &= ~(1U << sl);
 		if (pool->sl_bitmap[fl] == 0)
-			pool->fl_bitmap &= ~(1U << fl);
+			pool->fl_bitmap &= ~(UINT64_C(1) << fl);
 	}
 }
 
@@ -133,7 +139,7 @@ static void tlsf_insert_free_block(tlsf_pool_t* pool, free_block_t* blk, int fl,
 	pool->blocks[fl][sl] = blk;
 
 	pool->sl_bitmap[fl] |= (1U << sl);
-	pool->fl_bitmap |= (1U << fl);
+	pool->fl_bitmap |= (UINT64_C(1) << fl);
 }
 
 /* ---- Find best-fit free block ---- */
@@ -148,9 +154,15 @@ static free_block_t* tlsf_find_free_block(tlsf_pool_t* pool, size_t size) {
 		return pool->blocks[fl][found_sl];
 	}
 
-	uint32_t fl_masked = pool->fl_bitmap & ~((1U << fl) - 1);
+	/* no suitable second-level bucket left in this first-level class, so i
+	 * search strictly larger fl classes. including `fl` here wouldve let a
+	 * lower SL bucket win and return a block smaller than `size`, thats an
+	 * instant heap overflow in the caller --axiss */
+	uint64_t fl_masked = 0;
+	if ((size_t)(fl + 1) < FL_INDEX_COUNT)
+		fl_masked = pool->fl_bitmap & (~UINT64_C(0) << (fl + 1));
 	if (fl_masked) {
-		int found_fl = tlsf_ffs32(fl_masked);
+		int found_fl = tlsf_ffs64(fl_masked);
 		int found_sl = tlsf_ffs32(pool->sl_bitmap[found_fl]);
 		return pool->blocks[found_fl][found_sl];
 	}
@@ -209,6 +221,8 @@ int tlsf_add_memory(tlsf_pool_t* pool, void* mem, size_t size) {
 void* tlsf_malloc(tlsf_pool_t* pool, size_t size) {
 	if (!pool || !size)
 		return NULL;
+	if (size > (size_t)-1 - TLSF_HEADER_SIZE - TLSF_ALIGN_MASK)
+		return NULL;
 
 	/* `size` is the caller's requested *payload* size. The block we carve
 	 * out must also hold its own header, or the payload the caller actually
@@ -250,9 +264,14 @@ void* tlsf_malloc(tlsf_pool_t* pool, size_t size) {
 
 		blk_set_size(&blk->hdr, size, false, prev_free);
 
-		block_header_t* next = blk_next(&blk->hdr);
-		next->prev_size = size;
-		next->size &= ~BLOCK_FLAG_PREV_FREE;
+		/* the allocated block is followed by new_hdr, whose predecessor is
+		 * allocated. i make the block after the remainder point back by
+		 * the remainder's size and mark its predecessor as free --axiss */
+		new_hdr->prev_size = size;
+		new_hdr->size &= ~BLOCK_FLAG_PREV_FREE;
+		block_header_t* successor = blk_next(new_hdr);
+		successor->prev_size = new_size;
+		successor->size |= BLOCK_FLAG_PREV_FREE;
 
 		int nfl, nsl;
 		tlsf_mapping(new_size, &nfl, &nsl);
@@ -276,6 +295,11 @@ void tlsf_free(tlsf_pool_t* pool, void* ptr) {
 
 	block_header_t* hdr = blk_from_payload(ptr);
 	size_t cur_size = blk_size(hdr);
+	size_t allocated_size = cur_size;
+	/* not letting a repeated free unlink an allocated payload like its
+	 * first words were free-list pointers --axiss */
+	if (blk_is_free(hdr))
+		return;
 	bool was_prev_free = blk_prev_free(hdr);
 	size_t saved_prev_size = hdr->prev_size;
 
@@ -288,6 +312,15 @@ void tlsf_free(tlsf_pool_t* pool, void* ptr) {
 	if (was_prev_free && saved_prev_size > 0) {
 		block_header_t* prev = (block_header_t*)((char*)hdr - saved_prev_size);
 		size_t prev_sz = blk_size(prev);
+		/* merged block inherits the predecessor's PREV_FREE bit here, not
+		 * hdr's. hdr's bit only says `prev` is free, which we already know
+		 * in this branch. propagating it made the merged block claim the
+		 * block before `prev` was free even when it was actually
+		 * allocated, then on ITS next free TLSF unlinked that allocated
+		 * block like it was a free-list node. the resulting
+		 * next_free/prev_free garbage is exactly the 0x2000 -> 0x2010
+		 * translation fault i saw in Namdapha --axiss */
+		bool prev_prev_free = blk_prev_free(prev);
 
 		int fl, sl;
 		tlsf_mapping(prev_sz, &fl, &sl);
@@ -297,7 +330,7 @@ void tlsf_free(tlsf_pool_t* pool, void* ptr) {
 		cur_size += prev_sz;
 		hdr = prev;
 		/* hdr->prev_size stays the same (it was prev's prev_size) */
-		blk_set_size(hdr, cur_size, true, was_prev_free);
+		blk_set_size(hdr, cur_size, true, prev_prev_free);
 	}
 
 	/* 3. Coalesce(lol) forward */
@@ -324,7 +357,9 @@ void tlsf_free(tlsf_pool_t* pool, void* ptr) {
 	tlsf_mapping(blk_size(hdr), &fl, &sl);
 	tlsf_insert_free_block(pool, (free_block_t*)hdr, fl, sl);
 
-	pool->used_size -= (cur_size - TLSF_HEADER_SIZE);
+	size_t payload_size = allocated_size - TLSF_HEADER_SIZE;
+	pool->used_size = pool->used_size >= payload_size ?
+		pool->used_size - payload_size : 0;
 }
 
 void* tlsf_realloc(tlsf_pool_t* pool, void* ptr, size_t size) {
@@ -340,6 +375,8 @@ void* tlsf_realloc(tlsf_pool_t* pool, void* ptr, size_t size) {
 	 * block size (header included) that must actually be carved out — see
 	 * the same fix in tlsf_malloc(). Keep `size` untouched so the fallback
 	 * path below can still pass the original payload size to tlsf_malloc(). */
+	if (size > (size_t)-1 - TLSF_HEADER_SIZE - TLSF_ALIGN_MASK)
+		return NULL;
 	size_t need = TLSF_ALIGN_UP(size + TLSF_HEADER_SIZE);
 	if (need < TLSF_MIN_BLOCK_SIZE)
 		need = TLSF_MIN_BLOCK_SIZE;
@@ -360,13 +397,16 @@ void* tlsf_realloc(tlsf_pool_t* pool, void* ptr, size_t size) {
 			bool pf = blk_prev_free(hdr);
 			blk_set_size(hdr, need, false, pf);
 
-			block_header_t* next = blk_next(hdr);
-			next->prev_size = need;
+			/* hdr + need is the newly-created free block itself, its prev_size
+			 * already got set above, so updating the block after it instead --axiss */
+			block_header_t* next = blk_next(new_block);
+			next->prev_size = rem_size;
 			next->size |= BLOCK_FLAG_PREV_FREE;
 
 			int fl, sl;
 			tlsf_mapping(rem_size, &fl, &sl);
 			tlsf_insert_free_block(pool, (free_block_t*)new_block, fl, sl);
+			pool->used_size -= remaining;
 		}
 		return ptr;
 	}
@@ -391,8 +431,10 @@ void* tlsf_realloc(tlsf_pool_t* pool, void* ptr, size_t size) {
 				bool pf = blk_prev_free(hdr);
 				blk_set_size(hdr, need, false, pf);
 
-				block_header_t* next2 = blk_next(hdr);
-				next2->prev_size = need;
+				/* same as the shrink path, keeping new_block's metadata as is and
+				 * just updating the physical successor of the new free remainder --axiss */
+				block_header_t* next2 = blk_next(new_block);
+				next2->prev_size = rem_size;
 				next2->size |= BLOCK_FLAG_PREV_FREE;
 
 				int nfl, nsl;
@@ -428,6 +470,7 @@ void* tlsf_realloc(tlsf_pool_t* pool, void* ptr, size_t size) {
 		if (copy_size > 0)
 			memcpy(new_ptr, ptr, copy_size);
 	}
-	tlsf_free(pool, ptr);
+	if (new_ptr)
+		tlsf_free(pool, ptr);
 	return new_ptr;
 }

--- a/KernelAA64/Mm/vmmngr.c
+++ b/KernelAA64/Mm/vmmngr.c
@@ -78,53 +78,41 @@ void envmdebug() {
 	_vmdebug = 0;
 }
 
+/* a table has to be fully initialized and visible to the page-table walker
+ * before its parent descriptor gets published. cleaning only the parent
+ * PTE wouldve left stale contents sitting in a newly allocated child table
+ * on non-coherent table walks --axiss */
+static void vmm_prepare_table(uint64_t page) {
+	void* table = (void*)P2V(page);
+	memset(table, 0, 4096);
+	aa64_data_cache_clean_range(table, 4096);
+	dsb_ish();
+}
+
 /**
  * @brief AuVmmngrInitialize -- initialize the virtual memory manager
  */
 void AuVmmngrInitialize() {
 	AuTextOut("[aurora]: initializing virtual memory manager \r\n");
-	uint64_t* previousL0 = (uint64_t*)read_ttbr0_el1();
-	uint64_t* newL0 = AuPmmngrAlloc();
-	memset(newL0, 0, PAGE_SIZE);
-
-	for (int i = 0; i < 512; i++) {
-		newL0[i] = previousL0[i];
-	}
-
-	if (!AuLittleBootUsed()) {}
-
-	uint64_t* newL1 = AuPmmngrAlloc();
-	memset(newL1, 0, PAGE_SIZE);
-	newL0[pml4_index(PHYSICAL_MEM_BASE)] =
-		(uint64_t)newL1 | 0x3; // | PTE_VALID | PTE_TABLE | PTE_AF;
-	data_cache_flush(&newL0[pml4_index(PHYSICAL_MEM_BASE)]);
-
-	for (int i = 0; i < 512; i++) {
-		uint64_t addr = (uint64_t)i << 30;
-		newL1[pdpt_index(PHYSICAL_MEM_BASE) + i] =
-			(addr | (0ULL << 54) | (0ULL << 53) | (1ULL << 10) | (3ULL << 8) | (0ULL << 6) |
-			 (1UL << 2) | 0b01);
-		//data_cache_flush(&newL1[pdpt_index(PHYSICAL_MEM_BASE) + i]);
-	}
-	uint64_t* kernelAS = AuPmmngrAlloc();
-	memset(kernelAS, 0, PAGE_SIZE);
-
-	for (int i = 0; i < 512; i++) {
-		kernelAS[i] = newL0[i];
-	}
-
-	write_ttbr0_el1(newL0);
-	write_ttbr1_el1(kernelAS);
-
+	/* XNLDR installs the direct physical map while it still owns the
+	 * inherited firmware root, so i leave that active root alone here --axiss */
+	uint64_t* userRoot = (uint64_t*)read_ttbr0_el1();
+	uint64_t* kernelRoot = (uint64_t*)read_ttbr1_el1();
+	/* accessing the live root through the just-installed direct map here,
+	 * since the inherited low alias might point at a different firmware
+	 * translation --axiss */
+	uint64_t* liveKernelRoot =
+		(uint64_t*)(PHYSICAL_MEM_BASE + ((uint64_t)kernelRoot & ~0xFFFULL));
+	liveKernelRoot[pml4_index(KERNEL_BASE_ADDRESS)] = 0;
+	aa64_data_cache_clean_range(&liveKernelRoot[pml4_index(KERNEL_BASE_ADDRESS)],
+		sizeof(uint64_t));
 	tlb_flush_vmalle1is();
 
-	dsb_sy_barrier();
-	isb_flush();
-
-	_RootPaging = newL0;
-	_RootPagingKe = kernelAS;
+	_RootPaging = userRoot;
+	_RootPagingKe = kernelRoot;
 
 	AuPmmngrMoveHigher();
+	UARTDebugOut("[vmm]: direct map online\r\n");
 
 	//tlb_flush_vmalle1is();
 	_MMIOBase = (uint64_t*)MMIO_BASE;
@@ -154,51 +142,77 @@ bool AuMapPage(uint64_t phys_addr, uint64_t virt_addr, uint8_t attrib) {
 	}
 
 	if (!(pml4i[i4] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (_vmdebug)
 			UARTDebugOut("Creating pm4 entry : %x \r\n", page);
+		vmm_prepare_table(page);
 		pml4i[i4] = (page & ~0xFFFUL) | PTE_VALID | PTE_TABLE;
-		memset((void*)P2V(page), 0, 4096);
 		/*dsb_ish();
 		isb_flush();*/
 		void* address = &pml4i[i4];
 		//data_cache_flush((uint64_t*)address);
-		aa64_data_cache_clean_range(address, 4096);
+		/* only this one 8-byte entry got dirtied, not the whole parent
+		 * table page. cleaning all 4096 bytes here was flushing 63 clean
+		 * cache lines nobody even touched, every single time a new table
+		 * level got created during boot --axiss */
+		aa64_data_cache_clean_range(address, sizeof(uint64_t));
 	}
 	uint64_t* pml3 = (uint64_t*)P2V((pml4i[i4] & ~0xFFFULL));
 
 	if (!(pml3[i3] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (_vmdebug)
 			UARTDebugOut("Creating PML3 Entry : %x \r\n", page);
+		vmm_prepare_table(page);
 		pml3[i3] = (page & ~0xFFFUL) | PTE_VALID | PTE_TABLE;
-		memset((void*)P2V(page), 0, 4096);
 		/*dsb_ish();
 		isb_flush();*/
 		void* address = &pml3[i3];
 		//data_cache_flush((uint64_t*)address);
-		aa64_data_cache_clean_range(address, 4096);
+		/* same as the PML4 case above, only this entry is dirty --axiss */
+		aa64_data_cache_clean_range(address, sizeof(uint64_t));
 	}
 
-	uint64_t* pml2 = (uint64_t*)P2V((pml3[i3] & ~0xFFFULL));
+	uint64_t pml3e = pml3[i3];
+	/* a table descriptor carries a physical address, catching caller/table
+	 * corruption here before P2V wraps a high virtual value into FFFF7... --axiss */
+	if ((pml3e & PTE_VALID) && (pml3e & 0x0000FF0000000000ULL)) {
+		UARTDebugOut("[vmm]: invalid L1 descriptor va=%x desc=%x\r\n", virt_addr, pml3e);
+		return false;
+	}
+	if ((pml3e & 0x3) == PTE_VALID) {
+		UARTDebugOut("[vmm]: L1 block cannot be split va=%x desc=%x\r\n", virt_addr, pml3e);
+		return false;
+	}
+	uint64_t* pml2 = (uint64_t*)P2V((pml3e & ~0xFFFULL));
 
 	if (!(pml2[i2] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (_vmdebug)
 			UARTDebugOut("Creating PML2 Entry %x\r\n", page);
+		vmm_prepare_table(page);
 		pml2[i2] = (page & ~0xFFFUL) | PTE_VALID | PTE_TABLE;
-		memset((void*)P2V(page), 0, 4096);
 		/*dsb_ish();
 		isb_flush();*/
 		void* address = &pml2[i2];
 		//data_cache_flush((uint64_t*)address);
-		aa64_data_cache_clean_range(address, 4096);
+		/* same as the PML4 case above, only this entry is dirty --axiss */
+		aa64_data_cache_clean_range(address, sizeof(uint64_t));
 	}
 
-	uint64_t* pml1 = (uint64_t*)P2V((pml2[i2] & ~0xFFFULL));
+	uint64_t pml2e = pml2[i2];
+	if ((pml2e & PTE_VALID) && (pml2e & 0x0000FF0000000000ULL)) {
+		UARTDebugOut("[vmm]: invalid L2 descriptor va=%x desc=%x\r\n", virt_addr, pml2e);
+		return false;
+	}
+	if ((pml2e & 0x3) == PTE_VALID) {
+		UARTDebugOut("[vmm]: L2 block cannot be split va=%x desc=%x\r\n", virt_addr, pml2e);
+		return false;
+	}
+	uint64_t* pml1 = (uint64_t*)P2V((pml2e & ~0xFFFULL));
 
 	if (pml1[i1] & 1) {
-		//AuPmmngrFree((void*)phys_addr);
+		//AuPmmngrReleasePage((uint64_t)phys_addr);
 		AuTextOut("[aurora]: vmmngr page already present : virt=%x phys=%x \r\n",
 				  virt_addr,
 				  (pml1[i1] & ~0xFFFULL));
@@ -211,7 +225,11 @@ bool AuMapPage(uint64_t phys_addr, uint64_t virt_addr, uint8_t attrib) {
 	pml1[i1] = (phys_addr & ~0xFFFULL) | flags;
 	virt_addr &= ~0xFFFULL;
 	void* address = &pml1[i1];
-	aa64_data_cache_clean_range(address, 4096);
+	/* a single leaf PTE changed here, so i clean just its cache line before
+	 * invalidating the corresponding translation. cleaning the whole 4 KiB
+	 * table made every ordinary page map pay for 64 cache lines it didnt
+	 * need to --axiss */
+	aa64_data_cache_clean_range(address, sizeof(uint64_t));
 	dsb_ish();
 	isb_flush();
 
@@ -243,29 +261,32 @@ bool AuMapPageEx(uint64_t* pml4i, uint64_t phys_addr, uint64_t virt_addr, uint8_
 	//uint64_t* pml4i = (uint64_t*)pml4;
 
 	if (!(pml4i[i4] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+		vmm_prepare_table(page);
 		pml4i[i4] = (page & ~0xFFFUL) | PTE_VALID | PTE_TABLE | PTE_AF;
-		memset((void*)P2V(page), 0, 4096);
+		aa64_data_cache_clean_range(&pml4i[i4], sizeof(uint64_t));
 	}
 	uint64_t* pml3 = (uint64_t*)P2V((pml4i[i4] & ~0xFFFULL));
 
 	if (!(pml3[i3] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+		vmm_prepare_table(page);
 		pml3[i3] = (page & ~0xFFFUL) | PTE_VALID | PTE_TABLE | PTE_AF;
-		memset((void*)P2V(page), 0, 4096);
+		aa64_data_cache_clean_range(&pml3[i3], sizeof(uint64_t));
 	}
 
 	uint64_t* pml2 = (uint64_t*)P2V((pml3[i3] & ~0xFFFULL));
 
 	if (!(pml2[i2] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+		vmm_prepare_table(page);
 		pml2[i2] = (page & ~0xFFFUL) | PTE_VALID | PTE_TABLE | PTE_AF;
-		memset((void*)P2V(page), 0, 4096);
+		aa64_data_cache_clean_range(&pml2[i2], sizeof(uint64_t));
 	}
 
 	uint64_t* pml1 = (uint64_t*)P2V((pml2[i2] & ~0xFFFULL));
 	if (pml1[i1] & 1) {
-		//AuPmmngrFree((void*)phys_addr);
+		//AuPmmngrReleasePage((uint64_t)phys_addr);
 		AuTextOut("[aurora]: vmmngr page already present : virt=%x phys=%x \n",
 				  virt_addr,
 				  (pml1[i1] & ~0xFFFULL));
@@ -308,29 +329,29 @@ AuVPage* AuVmmngrGetPage(uint64_t virt_addr, uint8_t _flags, uint8_t mode) {
 		pml4i = (uint64_t*)P2V(read_ttbr1_el1());
 
 	if (!(pml4i[i4] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+		vmm_prepare_table(page);
 		pml4i[i4] = page | flags;
-		data_cache_flush(&pml4i[i4]);
-		memset((void*)P2V(page), 0, 4096);
+		aa64_data_cache_clean_range(&pml4i[i4], sizeof(uint64_t));
 		//tlb_flush((void*)pml4i);
 	}
 	uint64_t* pml3 = (uint64_t*)P2V(pml4i[i4] & ~0xFFFULL);
 
 	if (!(pml3[i3] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+		vmm_prepare_table(page);
 		pml3[i3] = page | flags;
-		data_cache_flush(&pml3[i3]);
-		memset((void*)P2V(page), 0, 4096);
+		aa64_data_cache_clean_range(&pml3[i3], sizeof(uint64_t));
 		//tlb_flush((void*)pml3);
 	}
 
 	uint64_t* pml2 = (uint64_t*)P2V(pml3[i3] & ~0xFFFULL);
 
 	if (!(pml2[i2] & 1)) {
-		const uint64_t page = (uint64_t)AuPmmngrAlloc();
+		const uint64_t page = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+		vmm_prepare_table(page);
 		pml2[i2] = page | flags;
-		data_cache_flush(&pml2[i2]);
-		memset((void*)P2V(page), 0, 4096);
+		aa64_data_cache_clean_range(&pml2[i2], sizeof(uint64_t));
 		//tlb_flush((void*)pml2);
 	}
 
@@ -340,7 +361,7 @@ AuVPage* AuVmmngrGetPage(uint64_t virt_addr, uint8_t _flags, uint8_t mode) {
 		return page;
 	} else {
 		if (mode & VIRT_GETPAGE_CREATE && !(mode & VIRT_GETPAGE_ONLY_RET)) {
-			uint64_t phys_addr = (uint64_t)AuPmmngrAlloc();
+			uint64_t phys_addr = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 			memset((void*)P2V(phys_addr), 0, 4096);
 			pml1[i1] = phys_addr & ~0xFFFULL | flags;
 			data_cache_flush(&pml1[i1]);
@@ -481,7 +502,7 @@ void AuFreePages(uint64_t virt_addr, bool free_physical, size_t s) {
 
 		if (free_physical && page != 0) {
 			UARTDebugOut("AuFreePages: Free physical : %x \r\n", V2P((uint64_t)page));
-			AuPmmngrFree((void*)V2P((size_t)page));
+			AuPmmngrReleasePage((uint64_t)V2P((size_t)page));
 		}
 		//data_cache_flush(virt_addr);
 		virt_addr += 4096;
@@ -583,7 +604,7 @@ void* AuGetPhysicalAddressEx(uint64_t* pml4_, uint64_t virt_addr) {
  */
 uint64_t* AuCreateVirtualAddressSpace() {
 	uint64_t* root_pml = (uint64_t*)P2V((size_t)_RootPagingKe);
-	uint64_t* new_pml = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* new_pml = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(new_pml, 0, PAGE_SIZE);
 
 	for (int i = 0; i < 512; i++) {

--- a/KernelAA64/Serv/fileserv.c
+++ b/KernelAA64/Serv/fileserv.c
@@ -65,6 +65,17 @@ int OpenFile(char* filename, int mode) {
 	char fname[128];
 	memset(fname, 0, 128);
 	fname[127] = '\0';
+	/* filename is a raw user pointer with no length guarantee, strcpy into
+	 * this fixed 128 byte kernel stack buffer with no bound check is a
+	 * straight up stack smash for anything >= 128 bytes, and any
+	 * unprivileged process can hit it (open() is syscall #12, anyone can
+	 * call it). found this chasing an unrelated crash in nmdapha, its a
+	 * real bug on its own either way but i couldnt confirm it actually
+	 * caused that crash (register dump at fault time didnt line up with
+	 * this call site), so dont treat this as "the fix" for that. rejecting
+	 * rather than overflowing regardless --axiss */
+	if (!filename || strlen(filename) >= sizeof(fname))
+		return -1;
 	strcpy(fname, filename);
 	AuVFSNode* fsys = AuVFSFind(fname);
 	int fd = AuProcessGetFileDesc(current_proc);
@@ -175,7 +186,7 @@ int FileSetOffset(int fd, size_t offset) {
  * @param length -- length in bytes
  */
 size_t ReadFile(int fd, void* buffer, size_t length) {
-	if (fd == -1)
+	if (fd < 0)
 		return 0;
 	if (!buffer)
 		return 0;
@@ -237,7 +248,7 @@ size_t ReadFile(int fd, void* buffer, size_t length) {
  * @param length -- length in bytes
  */
 size_t WriteFile(int fd, void* buffer, size_t length) {
-	if (fd == -1)
+	if (fd < 0)
 		return 0;
 	if (!buffer)
 		return 0;
@@ -270,11 +281,31 @@ size_t WriteFile(int fd, void* buffer, size_t length) {
 	AuVFSNode* fsys = (AuVFSNode*)file->device;
 
 	if (file->flags & FS_FLAG_GENERAL && !(file->flags & FS_FLAG_TTY)) {
-		uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
-		memset(buff, 0, PAGE_SIZE);
-		memcpy(buff, aligned_buffer, PAGE_SIZE);
-		AuVFSNodeWrite(fsys, file, buff, length);
-		AuPmmngrFree((void*)V2P((size_t)buff));
+		/* the staging buffer is one physical page and FatWrite only ever
+		 * sees that single page, but this used to hand it the *full*
+		 * length in one shot. for length > PAGE_SIZE that walked the
+		 * cluster loop right off the end of the staged page. it also
+		 * always memcpy'd a full PAGE_SIZE from the caller's buffer no
+		 * matter what length was, over-reading past shorter buffers.
+		 * fixed by feeding FatWrite one page at a time so each call
+		 * stays inside the page it actually has. FatFileWriteContent
+		 * tracks the write cursor on the node itself and
+		 * FatFileUpdateSize adds its size arg to the on-disk entry
+		 * instead of overwriting it, so the per-chunk calls here add up
+		 * correctly across the loop --axiss */
+		size_t remaining = length;
+		uint8_t* src = aligned_buffer;
+		while (remaining > 0) {
+			size_t chunk = remaining > PAGE_SIZE ? PAGE_SIZE : remaining;
+			uint64_t* buff = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
+			memset(buff, 0, PAGE_SIZE);
+			memcpy(buff, src, chunk);
+			AuVFSNodeWrite(fsys, file, buff, chunk);
+			AuPmmngrReleasePage((uint64_t)V2P((size_t)buff));
+			src += chunk;
+			remaining -= chunk;
+		}
+		return length;
 	}
 
 	if (file->flags & FS_FLAG_TTY) {
@@ -300,7 +331,7 @@ size_t WriteFile(int fd, void* buffer, size_t length) {
  * @param fd -- file descriptor to close
  */
 int CloseFile(int fd) {
-	if (fd == -1)
+	if (fd < 0)
 		return 0;
 	if (fd >= FILE_DESC_PER_PROCESS)
 		return 0;
@@ -315,6 +346,9 @@ int CloseFile(int fd) {
 	}
 
 	AuVFSNode* file = current_proc->fds[fd];
+	/* closing an fd that was never opened used to just crash here, no NULL check --axiss */
+	if (!file)
+		return -1;
 	if (file->flags & FS_FLAG_FILE_SYSTEM) {
 		current_proc->fds[fd] = 0;
 		BordoisilaCapDestroy(current_proc, fd);
@@ -329,15 +363,35 @@ int CloseFile(int fd) {
 	if (file->flags & FS_FLAG_GENERAL) {
 		current_proc->fds[fd] = 0;
 		BordoisilaCapDestroy(current_proc, fd);
-		/** NEED to fix, freeing the file causes crash **/
-		kfree(file);
+		/* this used to kfree() unconditionally (there was a TODO here
+		 * that just said "NEED to fix, freeing the file causes crash").
+		 * a dup'd fd, a fork-inherited fd, or a second open() of the
+		 * same path hitting the AuVFSOpen cache all bump fileCopyCount
+		 * and share the same AuVFSNode*, so freeing on the first
+		 * close() left every other reference dangling. AuProcessExit
+		 * already uses this same "<=0 means free" check for these
+		 * flags so at least this is consistent with that. heads up
+		 * though, FAT leaves a fresh node's fileCopyCount at 0 (memset)
+		 * while Ext2.c:406 sets it to 1, so the two filesystems dont
+		 * agree on what the field even means at open time. on an Ext2
+		 * node with no dups this never frees, same one-node-per-close
+		 * leak AuProcessExit already has. not fixing that here, out of
+		 * scope for this pass and theres no Ext2 image on this board
+		 * anyway --axiss */
+		if (file->fileCopyCount <= 0)
+			kfree(file);
+		else
+			file->fileCopyCount -= 1;
 		return 0;
 	}
 
 	if (file->flags & FS_FLAG_DIRECTORY) {
 		current_proc->fds[fd] = 0;
 		BordoisilaCapDestroy(current_proc, fd);
-		kfree(file);
+		if (file->fileCopyCount <= 0)
+			kfree(file);
+		else
+			file->fileCopyCount -= 1;
 		return 0;
 	}
 
@@ -348,6 +402,10 @@ int CloseFile(int fd) {
 		BordoisilaCapDestroy(current_proc, fd);
 		return 0;
 	}
+
+	/* flags matched none of the known types above, this used to just
+	 * fall off the end of the function with no return --axiss */
+	return -1;
 }
 
 /**
@@ -357,7 +415,7 @@ int CloseFile(int fd) {
  * @param arg -- argument to pass
  */
 int FileIoControl(int fd, int code, void* arg) {
-	if (fd == -1)
+	if (fd < 0)
 		return -1;
 	if (fd >= FILE_DESC_PER_PROCESS)
 		return 0;
@@ -387,7 +445,7 @@ int FileIoControl(int fd, int code, void* arg) {
  * @param buf -- Pointer to file structure
  */
 int FileStat(int fd, void* buf) {
-	if (fd == -1)
+	if (fd < 0)
 		return -1;
 	if (fd >= FILE_DESC_PER_PROCESS)
 		return -1;
@@ -458,7 +516,11 @@ int OpenDir(char* filename) {
 int ReadDir(int dirfd, void* dirent) {
 	if (!dirent)
 		return -1;
-	if (dirfd == -1)
+	if (dirfd < 0)
+		return -1;
+	/* only checked == -1 here before, no upper bound at all, so any
+	 * dirfd >= FILE_DESC_PER_PROCESS indexed straight past fds[] --axiss */
+	if (dirfd >= FILE_DESC_PER_PROCESS)
 		return -1;
 
 	AA64Thread* current_thr = AuGetCurrentThread();

--- a/KernelAA64/Sound/sndcore.c
+++ b/KernelAA64/Sound/sndcore.c
@@ -151,7 +151,7 @@ int AuSoundIOControl(AuVFSNode* node, int code, void* arg) {
 		UARTDebugOut("Registering sound player \r\n");
 		AuDSP* dsp = (AuDSP*)kmalloc(sizeof(AuDSP));
 		memset(dsp, 0, sizeof(AuDSP));
-		uint8_t* buffer = (uint8_t*)P2V((size_t)AuPmmngrAlloc());
+		uint8_t* buffer = (uint8_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		UARTDebugOut("buffer : %x \r\n", buffer);
 		memset(buffer, 0, PAGE_SIZE);
 		dsp->buffer = AuCircBufInitialise(buffer, SND_BUFF_SZ);
@@ -279,7 +279,7 @@ void AuSoundInitialise() {
 void AuSoundRemoveDSP(uint16_t id) {
 	AuDSP* dsp_ = AuSoundGetDSP(id);
 	if (dsp_) {
-		AuPmmngrFree((void*)V2P((size_t)dsp_->buffer->buffer));
+		AuPmmngrReleasePage((uint64_t)V2P((size_t)dsp_->buffer->buffer));
 		AuCircBufFree(dsp_->buffer);
 		AuRemoveDSP(dsp_);
 		kfree(dsp_);

--- a/KernelAA64/aucon.c
+++ b/KernelAA64/aucon.c
@@ -49,6 +49,7 @@
 #include <Fs/vfs.h>
 #include <Fs/Dev/devfs.h>
 #include <Drivers/uart.h>
+#include <Drivers/uart.h>
 #include <Hal/AA64/aa64cpu.h>
 #include <Hal/AA64/aa64lowlevel.h>
 #include <Ipc/postbox.h>
@@ -82,12 +83,12 @@ void AuTestPrint() {
  */
 void AuConsoleInitialize(PKERNEL_BOOT_INFO info, bool early) {
 	if (early) {
-		_print_func = info->printf_gui;
+		/* the UEFI loader callback points into XNLDR's image, cant rely on
+		 * that bs mapping once VM bootstrap kicks in since its not part
+		 * of the kernel address space --axiss */
+		_print_func = UARTDebugOut;
 		early_ = early;
-		if (info->boot_type == BOOT_LITTLEBOOT_ARM64) {
-			_print_func = UARTDebugOut;
-			AuUartPutString("[aurora]: printf function set to UARTDebugOut \r\n");
-		}
+		AuUartPutString("[aurora]: early console set to UARTDebugOut \r\n");
 	}
 	aucon = NULL;
 	bypass_autextout = false;

--- a/KernelAA64/audrv.c
+++ b/KernelAA64/audrv.c
@@ -317,7 +317,7 @@ void AuDriverLoad(char* filename, AuDriver* driver) {
 	PSECTION_HEADER sectionHeader =
 		RAW_OFFSET(PSECTION_HEADER, &nt->OptionalHeader, nt->FileHeader.SizeOfOptionaHeader);
 
-	uint64_t first_block = (uint64_t)AuPmmngrAlloc();
+	uint64_t first_block = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 	memset((void*)first_block, 0, 4096);
 	AuMapPage(first_block, driver_load_base, PTE_NORMAL_MEM);
 	memcpy((void*)driver_load_base, scratchBuffer, nt->OptionalHeader.SizeOfHeaders);
@@ -337,7 +337,7 @@ void AuDriverLoad(char* filename, AuDriver* driver) {
 		for (int j = 0; j < req_pages; j++) {
 			uint64_t alloc = (aligned_addr + j * 0x1000);
 			if (!AuGetPhysicalAddress(alloc)) {
-				AuMapPage((uint64_t)AuPmmngrAlloc(), alloc, PTE_NORMAL_MEM);
+				AuMapPage((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL), alloc, PTE_NORMAL_MEM);
 				memset((void*)alloc, 0, 4096);
 				next_base_offset++;
 			}
@@ -390,13 +390,19 @@ void AuDrvMngrInitialize(KERNEL_BOOT_INFO* info) {
 	driver_load_base = AU_DRIVER_BASE_START;
 	_dev_count_ = 0;
 
-	scratchBuffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocBlocks((1024 * 1024) / 0x1000));
+	/* I copy driver images through this 1 MiB physically contiguous area, fragile but works? --axiss */
+	scratchBuffer = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPages(
+		(1024 * 1024) / 0x1000, 1, 0, AURORA_PAGE_KERNEL));
+	if (!scratchBuffer) {
+		AuTextOut("[aurora]: unable to allocate driver scratch memory\r\n");
+		return;
+	}
 	memset(scratchBuffer, 0, 1024 * 1024);
 
 	AuTextOut("[aurora]: initializing drivers, please wait... \r\n");
 	/* Load the conf data */
-	uint64_t* conf = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
-	uint64_t* boardcnf = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* conf = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
+	uint64_t* boardcnf = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(conf, 0, PAGE_SIZE);
 	memset(boardcnf, 0, PAGE_SIZE);
 

--- a/KernelAA64/clean.c
+++ b/KernelAA64/clean.c
@@ -47,10 +47,9 @@ void AuCleanMMap(AuProcess* proc) {
 		/* also do check, if the physical address is backed by file, 
 		 * need to behave differently with file backed physical addresses 
 		 */
-		AuPageDesc* desc = AuPmmngrGetPageDesc(phys);
 		if (phys != 0) {
-			if (desc->diskblock == -1) {
-				AuPmmngrFree((void*)phys);
+			if (AuPmmngrGetBackingBlock(phys) == -1) {
+				AuPmmngrReleasePage((uint64_t)phys);
 			}
 		}
 	}
@@ -66,9 +65,8 @@ void AuCleanHeapMem(AuProcess* proc) {
 		uint64_t phys =
 			(uint64_t)AuGetPhysicalAddressEx(proc->cr3, PROCESS_BREAK_ADDRESS + i * 0x1000);
 		if (phys) {
-			AuPageDesc* desc = AuPmmngrGetPageDesc(phys);
-			if (desc->diskblock == -1)
-				AuPmmngrFree((void*)phys);
+			if (AuPmmngrGetBackingBlock(phys) == -1)
+				AuPmmngrReleasePage((uint64_t)phys);
 		}
 	}
 	proc->proc_heapmem_len = 0;
@@ -85,9 +83,8 @@ void AuCleanUserStack(AuProcess* proc, AuUserEntry* uentry) {
 	for (int i = 0; i < PROCESS_USER_STACK_SZ / 0x1000; i++) {
 		uint64_t phys = (uint64_t)AuGetPhysicalAddressEx(proc->cr3, location + i * 0x1000);
 		if (phys) {
-			AuPageDesc* desc = AuPmmngrGetPageDesc(phys);
-			if (desc->diskblock == -1)
-				AuPmmngrFree((void*)phys);
+			if (AuPmmngrGetBackingBlock(phys) == -1)
+				AuPmmngrReleasePage((uint64_t)phys);
 		}
 	}
 }
@@ -103,9 +100,8 @@ void AuCleanKernelStack(AuProcess* proc, AA64Thread* thr) {
 	for (int i = 0; i < KERNEL_STACK_SIZE / 0x1000; i++) {
 		uint64_t phys = (uint64_t)AuGetPhysicalAddress(location + i * 0x1000);
 		if (phys) {
-			AuPageDesc* desc = AuPmmngrGetPageDesc(phys);
-			if (desc->diskblock == -1)
-				AuPmmngrFree((void*)phys);
+			if (AuPmmngrGetBackingBlock(phys) == -1)
+				AuPmmngrReleasePage((uint64_t)phys);
 		}
 	}
 }
@@ -159,7 +155,7 @@ void AuProcessClean(AuProcess* parent, AuProcess* killable) {
 		if (uentry->argvaddr != 0) {
 			void* phys = AuGetPhysicalAddressEx(killable->cr3, uentry->argvaddr);
 			if (phys)
-				AuPmmngrFree((void*)phys);
+				AuPmmngrReleasePage((uint64_t)phys);
 		}
 	}
 
@@ -172,7 +168,7 @@ void AuProcessClean(AuProcess* parent, AuProcess* killable) {
 			if (subthr->uentry->argvaddr != 0) {
 				void* phys = AuGetPhysicalAddressEx(killable->cr3, subthr->uentry->argvaddr);
 				if (phys)
-					AuPmmngrFree((void*)phys);
+					AuPmmngrReleasePage((uint64_t)phys);
 			}
 		}
 	}
@@ -180,7 +176,7 @@ void AuProcessClean(AuProcess* parent, AuProcess* killable) {
 	/** free up environment block **/
 	void* envBlock = AuGetPhysicalAddressEx(killable->cr3, 0x5000);
 	if (envBlock)
-		AuPmmngrFree((void*)envBlock);
+		AuPmmngrReleasePage((uint64_t)envBlock);
 
 	/** free up uentry structs **/
 	if (uentry)
@@ -213,9 +209,11 @@ void AuProcessClean(AuProcess* parent, AuProcess* killable) {
 	/** clear up the process data structure **/
 	AuRemoveProcess(parent, killable);
 
-	size_t totalRam = (AuPmmngrGetTotalMem() * 0x1000) / 1024 / 1024;
-	size_t usedRam = (AuPmmngrGetUsedMem() * 0x1000) / 1024 / 1024;
-	size_t freeRam = (AuPmmngrGetFreeMem() * 0x1000) / 1024 / 1024;
+	AuPmmStats pmm_stats;
+	AuPmmngrGetStats(&pmm_stats);
+	size_t totalRam = (pmm_stats.managed_pages * 0x1000) / 1024 / 1024;
+	size_t usedRam = (pmm_stats.allocated_pages * 0x1000) / 1024 / 1024;
+	size_t freeRam = (pmm_stats.free_pages * 0x1000) / 1024 / 1024;
 	UARTDebugOut("[aurora-clean]: process cleaned successfully \r\n");
 	UARTDebugOut(
 		"total mem : %d mb, used mem : %d mb , free mem : %d mb\r\n", totalRam, usedRam, freeRam);

--- a/KernelAA64/ftmngr.c
+++ b/KernelAA64/ftmngr.c
@@ -121,6 +121,34 @@ FontSeg* FontManagerAllocateSegment(AuVFSNode* fontfile, char* fontname) {
 }
 
 /**
+ * @brief FontManagerReadSegment -- read a font segment
+ * @param fs -- file system
+ * @param file -- font file
+ * @param seg -- font segment
+ * @return true if successful, false otherwise
+ */
+ // need better rasterization algorithm for font rendering, currently it is just a simple bitmap rendering --axiss
+static bool FontManagerReadSegment(AuVFSNode* fs, AuVFSNode* file, FontSeg* seg) {
+	if (!fs || !file || !seg || !seg->sharedSeg)
+		return false;
+
+	uint64_t remaining = file->size;
+	for (uint64_t i = 0; i < seg->sharedSeg->num_frames && remaining; ++i) {
+		uint64_t chunk = remaining > PAGE_SIZE ? PAGE_SIZE : remaining;
+		uint64_t phys = seg->sharedSeg->frames[i];
+		if (phys == PMM_INVALID_PHYS)
+			return false;
+		void* destination = (void*)P2V(phys);
+		memset(destination, 0, PAGE_SIZE);
+		size_t read = AuVFSNodeRead(fs, file, destination, chunk);
+		if (read != chunk)
+			return false;
+		remaining -= chunk;
+	}
+	return remaining == 0;
+}
+
+/**
  * @brief FontManagerOpenFontFile-- opens a font file
  * from disk
  * @return font file opened by font manager
@@ -179,10 +207,12 @@ search:
 	if (fontfile) {
 		UARTDebugOut("Font file present \r\n");
 		FontSeg* seg = FontManagerAllocateSegment(fontfile, fontname);
-		uint64_t* firstFrame = (uint64_t*)seg->sharedSeg->frames[0];
 		UARTDebugOut("fontfile -> %s sz : %d \r\n", fontfile->filename, fontfile->size);
-		size_t ret = AuVFSNodeRead(
-			fs, fontfile, (uint64_t*)P2V((size_t)firstFrame), ALIGN_UP(fontfile->size, 4096));
+		if (!FontManagerReadSegment(fs, fontfile, seg)) {
+			UARTDebugOut("[ftmngr]: failed to populate %s\r\n", fontfile->filename);
+			kfree(fontfile);
+			return;
+		}
 		fcount++;
 		kfree(fontfile); //avoiding this, because we need more powerful heap memory allocator
 	}
@@ -237,7 +267,7 @@ void FontManagerInitialise() {
 	UARTDebugOut("Font this %d bytes numPage: %d \r\n", fontconf->size, num_pages);
 	uint64_t* first_addr = NULL;
 	for (int i = 0; i < num_pages; i++) {
-		uint64_t* addr = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+		uint64_t* addr = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		if (!first_addr)
 			first_addr = addr;
 	}

--- a/KernelAA64/kernel_exports.c
+++ b/KernelAA64/kernel_exports.c
@@ -19,8 +19,10 @@ extern void GICEnableSPIIRQ(void);
 extern void AuGICAllocateSPI(void);
 extern void GICRegisterSPIHandler(void);
 extern void UARTDebugOut(void);
-extern void AuPmmngrAlloc(void);
-extern void AuPmmngrAllocBlocks(void);
+extern void AuPmmngrAllocPage(void);
+extern void AuPmmngrAllocPages(void);
+extern void AuPmmngrReleasePage(void);
+extern void AuPmmngrReleasePages(void);
 extern void AuTextOut(void);
 extern void AuAddNetAdapter(void);
 extern void AuMapMMIO(void);
@@ -42,8 +44,10 @@ struct kernel_export k_exports[] = {
 	{"AuGICAllocateSPI", (void*)AuGICAllocateSPI},
 	{"GICRegisterSPIHandler", (void*)GICRegisterSPIHandler},
 	{"UARTDebugOut", (void*)UARTDebugOut},
-	{"AuPmmngrAlloc", (void*)AuPmmngrAlloc},
-	{"AuPmmngrAllocBlocks", (void*)AuPmmngrAllocBlocks},
+	{"AuPmmngrAllocPage", (void*)AuPmmngrAllocPage},
+	{"AuPmmngrAllocPages", (void*)AuPmmngrAllocPages},
+	{"AuPmmngrReleasePage", (void*)AuPmmngrReleasePage},
+	{"AuPmmngrReleasePages", (void*)AuPmmngrReleasePages},
 	{"P2V", (void*)P2V},
 	{"AuTextOut", (void*)AuTextOut},
 	{"AuAddNetAdapter", (void*)AuAddNetAdapter},

--- a/KernelAA64/loader.c
+++ b/KernelAA64/loader.c
@@ -174,7 +174,7 @@ void AuLoaderMapExecFromCache(AuProcess* proc,
 		for (size_t v_page = (load_addr & ~0xFFFULL); v_page < end_addr; v_page += PAGE_SIZE) {
 			void* phys = AuGetPhysicalAddressEx(proc->cr3, v_page);
 			if (!phys) {
-				phys = AuPmmngrAlloc();
+				phys = (void*)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 				memset((void*)P2V((size_t)phys), 0, PAGE_SIZE);
 				AuMapPageEx(proc->cr3,
 							(uint64_t)phys,
@@ -276,7 +276,7 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 
 		size_t total_pages = file_offset / PAGE_SIZE + ((file_offset % PAGE_SIZE) ? 1 : 0);
 		for (size_t i = 0; i < total_pages; i++) {
-			uint64_t physcache = (uint64_t)AuPmmngrAlloc();
+			uint64_t physcache = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 			AuMMPageCache* cache = AuMmngrPageCacheCreate();
 			cache->physicalPage = physcache;
 			cache->diskBlock = 0;
@@ -325,7 +325,7 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 		//AuMmngrRemoveFileBack(fb);
 		//aa64_data_cache_clean_range(file, sizeof(AuVFSNode));
 		//kfree(file);
-		//AuPmmngrFree((void*)V2P((sizeof(buf))));
+		//AuPmmngrReleasePage((uint64_t)V2P((sizeof(buf))));
 
 		/* now load XELoader process, which'll further
 		 * link this dynamic process with its shared
@@ -389,7 +389,7 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 	uint64_t argvkernel = 0;
 	if (num_args) {
 		/* Allocate a memory for passing arguments */
-		uint64_t* args = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+		uint64_t* args = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 		memset(args, 0, PAGE_SIZE);
 		if (!AuMapPageEx(proc->cr3,
 						 (size_t)V2P((uint64_t)args),
@@ -423,7 +423,7 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
  */
 void AuInitialiseLoader() {
 	for (int i = 0; i < (1024 * 1024) / 0x1000; i++) {
-		AuMapPage((size_t)AuPmmngrAlloc(), LOADER_SCRATCH_VIRT + i * 0x1000, PTE_NORMAL_MEM);
+		AuMapPage((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL), LOADER_SCRATCH_VIRT + i * 0x1000, PTE_NORMAL_MEM);
 	}
 	_ldr_scratchBuffer = (uint64_t*)
 		LOADER_SCRATCH_VIRT; // (uint64_t*)P2V((uint64_t)AuPmmngrAllocBlocks((1024 * 1024) / 0x1000));

--- a/KernelAA64/power.c
+++ b/KernelAA64/power.c
@@ -39,6 +39,7 @@
 #include <Hal/AA64/gic.h>
 #include <Drivers/uart.h>
 #include <Drivers/virtio.h>
+#include <Fs/vdisk.h>
 
 /**
  * @brief AuPowerDown -- power down system call
@@ -58,10 +59,10 @@ int AuPowerDown() {
 	if (proc->creds.gid != 0)
 		return 1;
 
-	/** TODO : Flush all system resources that needs disk
-	 * writes and call board power down which will handle
-	 * powering down of the board
-	 */
+	/* flush every registered disk's write cache before tearing anything
+	 * down. still a no-op per disk til some storage driver actually
+	 * populates AuVDisk::Flush --axiss */
+	AuVDiskFlushAll();
 
 #ifdef __TARGET_BOARD_QEMU_VIRT__
 	AuVirtioKbdDown();
@@ -78,8 +79,10 @@ int AuPowerDown() {
 	/* de-initialize the interrupt controller*/
 	GICDisable();
 
-	//aa64_clean_invalidate_dcache();
-	tlb_flush_vmalle1is();
+	/* dirty cache lines were getting lost across power-off/reset
+	 * with this commented out --axiss */
+	aa64_clean_invalidate_dcache();
+	tlb_flush_vmalle1is(); //need better naming schems boss --axiss
 
 	AuAA64BoardPowerDown();
 
@@ -105,10 +108,10 @@ void AuPowerReset() {
 	if (proc->creds.gid != 0)
 		return;
 
-	/** TODO : Flush all system resources that needs disk
-	 * writes and call board power down which will handle
-	 * powering down of the board
-	 */
+	/* flush every registered disk's write cache before tearing anything
+	 * down, still a no-op per disk since no storage driver actually
+	 * populates AuVDisk::Flush yet --axiss */
+	AuVDiskFlushAll();
 
 #ifdef __TARGET_BOARD_QEMU_VIRT__
 	AuVirtioKbdDown();
@@ -125,7 +128,9 @@ void AuPowerReset() {
 	/* de-initialize the interrupt controller */
 	GICDisable();
 
-	//aa64_clean_invalidate_dcache();
+	/* dirty cache lines, disk I/O buffers included, were getting lost
+	 * across power-off/reset with this commented out --axiss */
+	aa64_clean_invalidate_dcache();
 	tlb_flush_vmalle1is();
 
 	AuAA64BoardReboot();

--- a/KernelAA64/process.c
+++ b/KernelAA64/process.c
@@ -194,7 +194,7 @@ uint64_t* CreateUserStack(AuProcess* proc, uint64_t* cr3) {
 	location += proc->_user_stack_index_;
 
 	for (int i = 0; i < (PROCESS_USER_STACK_SZ / PAGE_SIZE); ++i) {
-		uint64_t blk = (uint64_t)AuPmmngrAlloc();
+		uint64_t blk = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (!AuMapPageEx(
 				cr3, blk, location + i * PAGE_SIZE, PTE_NORMAL_MEM | PTE_AP_RW_USER | PTE_AP_RW)) {
 			UARTDebugOut("CreateUserStack: already mapped %x \r\n", (location + i * PAGE_SIZE));
@@ -219,7 +219,7 @@ uint64_t* CreateSubUserStack(AuProcess* proc, uint64_t* cr3) {
 	location += proc->_user_stack_index_;
 
 	for (int i = 0; i < (PROCESS_USER_STACK_SZ / PAGE_SIZE); ++i) {
-		uint64_t blk = (uint64_t)AuPmmngrAlloc();
+		uint64_t blk = (uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
 		if (!AuMapPage(blk, location + i * PAGE_SIZE, PTE_AP_RW_USER | PTE_AP_RW)) {
 			UARTDebugOut("CreateUserStack: already mapped %x \r\n", (location + i * PAGE_SIZE));
 		}
@@ -252,7 +252,7 @@ AuProcess* AuCreateProcessSlot(AuProcess* parent, char* name) {
 	proc->_main_stack_ = main_thr_stack;
 	proc->prev_sample_time_us = AuGetCurrentUS();
 	proc->prev_sample_runtime_us = 0;
-	uint64_t* envpBlock = (uint64_t*)P2V((size_t)AuPmmngrAlloc());
+	uint64_t* envpBlock = (uint64_t*)P2V((size_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memset(envpBlock, 0, PAGE_SIZE);
 
 	/** confusing code :hehehehe **/
@@ -351,7 +351,7 @@ void AuProcessHeapMemDestroy(AuProcess* proc) {
 #if 0
 				UARTDebugOut("Heap mem destroy -> %x \r\n", phys);
 #endif
-				AuPmmngrFree((void*)phys);
+				AuPmmngrReleasePage((uint64_t)phys);
 			}
 			page->bits.page = 0;
 			isb_flush();

--- a/KernelAA64/signal.c
+++ b/KernelAA64/signal.c
@@ -120,7 +120,7 @@ bool AuSignalDeliver(AA64Thread* current_thread) {
  * @param t -- pointer to thread struct
  */
 void AuSignalInitializeTrampoline(AA64Thread* t) {
-	uint64_t* phys = (uint64_t*)P2V((uint64_t)AuPmmngrAlloc());
+	uint64_t* phys = (uint64_t*)P2V((uint64_t)AuPmmngrAllocPage(AURORA_PAGE_NORMAL));
 	memcpy(phys, &aa64_signal_return, PAGE_SIZE);
 	AuMapPageEx((uint64_t*)t->pml,
 				V2P((uint64_t)phys),

--- a/Libs/Chitralekha/draw.cpp
+++ b/Libs/Chitralekha/draw.cpp
@@ -44,9 +44,20 @@
  * @param h -- Height of the rect
  */
 void ChDrawRect(ChCanvas* canvas, unsigned x, unsigned y, unsigned w, unsigned h, uint32_t col) {
-	for (int i = 0; i < w; i++)
-		for (int j = 0; j < h; j++)
-			ChDrawPixel(canvas, x + i, y + j, col);
+	if (!canvas || !canvas->buffer || x >= canvas->canvasWidth || y >= canvas->canvasHeight)
+		return;
+	if (w > canvas->canvasWidth - x)
+		w = canvas->canvasWidth - x;
+	if (h > canvas->canvasHeight - y)
+		h = canvas->canvasHeight - y;
+#ifdef COLOR_BGRA
+	col = ChColorRGBAtoBGRA(col);
+#endif
+	for (unsigned row = 0; row < h; ++row) {
+		uint32_t* dst = canvas->buffer + (uint64_t)(y + row) * canvas->canvasWidth + x;
+		for (unsigned column = 0; column < w; ++column)
+			dst[column] = col;
+	}
 }
 
 /*

--- a/Libs/Chitralekha/font.cpp
+++ b/Libs/Chitralekha/font.cpp
@@ -38,13 +38,109 @@
 #include "color.h"
 #include FT_FREETYPE_H
 
+#ifndef _USE_FREETYPE
+/* our libc only has acosf (float), no acos (double). stb hides STBTT_cos
+ * and STBTT_acos behind the same #ifndef STBTT_cos guard so if you only
+ * define one, stb silently clobbers the other with its default.
+ * learned that one the hard way --axiss */
+#define STBTT_cos(x) cos(x)
+#define STBTT_acos(x) ((double)acosf((float)(x)))
+#define STBTT_assert(x) ((void)0)
+#define STB_TRUETYPE_IMPLEMENTATION
+#include "stb_truetype.h"
+#endif
+
+#ifndef _USE_FREETYPE
+static void ChFontClearGlyphCache(ChFont* font) {
+	for (int i = 0; i < CH_FONT_GLYPH_CACHE_SIZE; ++i) {
+		if (font->glyphCache[i].bitmap)
+			stbtt_FreeBitmap(font->glyphCache[i].bitmap, NULL);
+		memset(&font->glyphCache[i], 0, sizeof(font->glyphCache[i]));
+	}
+}
+
+static ChFontGlyphCacheEntry* ChFontGetCachedGlyph(ChFont* font, unsigned char codepoint) {
+	ChFontGlyphCacheEntry* glyph = &font->glyphCache[codepoint];
+	if (glyph->loaded)
+		return glyph;
+
+	int advance = 0;
+	int lsb = 0;
+	stbtt_GetCodepointHMetrics(&font->stbFont, codepoint, &advance, &lsb);
+	int width = 0;
+	int height = 0;
+	int xOffset = 0;
+	int yOffset = 0;
+	glyph->bitmap = stbtt_GetCodepointBitmap(
+		&font->stbFont, font->stbScale, font->stbScale, codepoint, &width, &height, &xOffset, &yOffset);
+	glyph->width = (int16_t)width;
+	glyph->height = (int16_t)height;
+	glyph->xOffset = (int16_t)xOffset;
+	glyph->yOffset = (int16_t)yOffset;
+	glyph->advance = (int16_t)(advance * font->stbScale);
+	glyph->loaded = 1;
+	return glyph;
+}
+
+static inline uint32_t ChFontBlendCoverage(uint32_t dst, uint32_t src, uint8_t coverage) {
+	if (coverage == 255)
+		return 0xFF000000U | (src & 0x00FFFFFFU);
+	uint32_t inv = 255U - coverage;
+	uint32_t red = ((((src >> 16) & 0xFFU) * coverage) + (((dst >> 16) & 0xFFU) * inv) + 127U) / 255U;
+	uint32_t green = ((((src >> 8) & 0xFFU) * coverage) + (((dst >> 8) & 0xFFU) * inv) + 127U) / 255U;
+	uint32_t blue = (((src & 0xFFU) * coverage) + ((dst & 0xFFU) * inv) + 127U) / 255U;
+	return 0xFF000000U | (red << 16) | (green << 8) | blue;
+}
+
+static void ChFontBlitGlyph(
+	ChCanvas* canv, const ChFontGlyphCacheEntry* glyph, int penx, int peny, uint32_t color, const ChRect* clip) {
+	if (!glyph->bitmap || glyph->width <= 0 || glyph->height <= 0)
+		return;
+
+	int left = penx + glyph->xOffset;
+	int top = peny + glyph->yOffset;
+	int right = left + glyph->width;
+	int bottom = top + glyph->height;
+	int clipLeft = 0;
+	int clipTop = 0;
+	int clipRight = canv->canvasWidth;
+	int clipBottom = canv->canvasHeight;
+	if (clip) {
+		if (clip->x > clipLeft) clipLeft = clip->x;
+		if (clip->y > clipTop) clipTop = clip->y;
+		if (clip->x + clip->w < clipRight) clipRight = clip->x + clip->w;
+		if (clip->y + clip->h < clipBottom) clipBottom = clip->y + clip->h;
+	}
+	if (left < clipLeft) left = clipLeft;
+	if (top < clipTop) top = clipTop;
+	if (right > clipRight) right = clipRight;
+	if (bottom > clipBottom) bottom = clipBottom;
+	if (left >= right || top >= bottom)
+		return;
+
+	for (int y = top; y < bottom; ++y) {
+		const uint8_t* source = glyph->bitmap + (y - (peny + glyph->yOffset)) * glyph->width + (left - (penx + glyph->xOffset));
+		uint32_t* destination = canv->buffer + y * canv->canvasWidth + left;
+		for (int x = left; x < right; ++x, ++source, ++destination) {
+			if (*source)
+				*destination = ChFontBlendCoverage(*destination, color, *source);
+		}
+	}
+}
+#endif
+
 /* 
  * ChInitialiseFont -- initialise a font by a name
  * @param fontname -- name of the font
  */
 ChFont* ChInitialiseFont(char* fontname) {
 	int id = _KeGetFontID(fontname);
-	if (id == 0)
+	/* AuFTMngrGetFontID returns -1 when it cant find the font, not 0. this
+	 * was only checking == 0 so -1 slipped right through as "valid", then
+	 * unpacked into garbage _font_id/_font_key. _KeObtainSharedMem usually
+	 * failed on that garbage but not always, which made this a fun one to
+	 * chase down --axiss */
+	if (id <= 0)
 		return NULL;
 	int _font_id = (id >> 16) & UINT16_MAX;
 	int _font_key = id & UINT16_MAX;
@@ -52,9 +148,13 @@ ChFont* ChInitialiseFont(char* fontname) {
 	if (!buff)
 		return NULL;
 
-	uint32_t fileSz = _KeGetFontSize(fontname);
-	if (!fileSz)
+	/* same -1 vs 0 bug as above. AuFTMngrGetFontSize returns -1 on failure
+	 * but it was getting shoved straight into a uint32_t, so -1 becomes
+	 * 0xFFFFFFFF. never zero, so the `!fileSz` check below never caught it --axiss */
+	int _fileSz = _KeGetFontSize(fontname);
+	if (_fileSz <= 0)
 		return NULL;
+	uint32_t fileSz = (uint32_t)_fileSz;
 
 	ChFont* font = (ChFont*)malloc(sizeof(ChFont));
 	memset(font, 0, sizeof(ChFont));
@@ -64,14 +164,41 @@ ChFont* ChInitialiseFont(char* fontname) {
 	font->key = _font_key;
 	font->kern = 0;
 #ifdef _USE_FREETYPE
+	/* none of these three error checks existed before. if any of them failed,
+	 * font->face (or ->size) stays NULL and the code below just dereferenced
+	 * it anyway, crashing whatever app happened to be loading a font right
+	 * then --axiss */
 	FT_Error err = 0;
 	err = FT_Init_FreeType(&font->lib);
+	if (err) {
+		free(font);
+		return NULL;
+	}
 	err = FT_New_Memory_Face(font->lib, font->buffer, font->fileSz, 0, &font->face);
+	if (err) {
+		free(font);
+		return NULL;
+	}
 
 	err = FT_Set_Pixel_Sizes(font->face, 0, 32);
+	if (err) {
+		free(font);
+		return NULL;
+	}
 	font->slot = font->face->glyph;
 	font->lineHeight = font->face->size->metrics.height / 64;
 	font->fontHeight = 32 / 72.f * 96;
+#else
+	int stbOffset = stbtt_GetFontOffsetForIndex(font->buffer, 0);
+	if (stbOffset < 0 || !stbtt_InitFont(&font->stbFont, font->buffer, stbOffset)) {
+		free(font);
+		return NULL;
+	}
+	font->fontHeight = (uint32_t)(32 / 72.f * 96);
+	font->stbScale = stbtt_ScaleForPixelHeight(&font->stbFont, (float)font->fontHeight);
+	stbtt_GetFontVMetrics(&font->stbFont, &font->stbAscent, &font->stbDescent, &font->stbLineGap);
+	font->lineHeight =
+		(uint32_t)((font->stbAscent - font->stbDescent + font->stbLineGap) * font->stbScale);
 #endif
 	/* start decoding true type font */
 	//TTFLoadFont(canv,font->buffer);
@@ -86,9 +213,19 @@ ChFont* ChInitialiseFont(char* fontname) {
 void ChFontSetSize(ChFont* font, int size) {
 	if (!font)
 		return;
-	font->fontSz = size / 72.f * 96;
+	uint32_t pixelSize = (uint32_t)(size / 72.f * 96);
+	if (pixelSize == 0)
+		pixelSize = 1;
+	if (font->fontSz == pixelSize)
+		return;
+	font->fontSz = pixelSize;
 #ifdef _USE_FREETYPE
 	FT_Set_Pixel_Sizes(font->face, 0, font->fontSz);
+#else
+	ChFontClearGlyphCache(font);
+	font->stbScale = stbtt_ScaleForPixelHeight(&font->stbFont, (float)font->fontSz);
+	font->lineHeight =
+		(uint32_t)((font->stbAscent - font->stbDescent + font->stbLineGap) * font->stbScale);
 #endif
 	font->fontHeight = font->fontSz;
 }
@@ -154,6 +291,22 @@ void ChFontDrawText(
 		prev = glyfIndx;
 		string++;
 	}
+#else
+	if (!font)
+		return;
+	int prevCp = 0;
+	while (*string) {
+		unsigned char cp = (unsigned char)*string;
+		if (prevCp) {
+			int kern = stbtt_GetCodepointKernAdvance(&font->stbFont, prevCp, cp);
+			penx += (int)(kern * font->stbScale);
+		}
+		ChFontGlyphCacheEntry* glyph = ChFontGetCachedGlyph(font, cp);
+		ChFontBlitGlyph(canv, glyph, penx, peny, color, NULL);
+		penx += glyph->advance;
+		prevCp = cp;
+		string++;
+	}
 #endif
 }
 
@@ -212,6 +365,22 @@ void ChFontDrawChar(
 		}
 	}
 	font->kern = glyfIndx;
+#else
+	if (!font)
+		return;
+	if (penx >= canv->canvasWidth)
+		return;
+	if (peny >= canv->canvasHeight)
+		return;
+
+	unsigned char cp = (unsigned char)c;
+	if (font->kern) {
+		int kern = stbtt_GetCodepointKernAdvance(&font->stbFont, (int)font->kern, cp);
+		penx += (int)(kern * font->stbScale);
+	}
+	ChFontGlyphCacheEntry* glyph = ChFontGetCachedGlyph(font, cp);
+	ChFontBlitGlyph(canv, glyph, penx, peny, color, NULL);
+	font->kern = (uint32_t)cp;
 #endif
 }
 
@@ -316,6 +485,19 @@ void ChFontDrawCharClipped(
 	font->kern = glyfIndx;
 	penx += font->face->glyph->advance.x >> 6;
 	peny += font->face->glyph->advance.y >> 6;
+#else
+	if (!font)
+		return;
+	if (!limit)
+		return;
+	unsigned char cp = (unsigned char)c;
+	if (font->kern) {
+		int kern = stbtt_GetCodepointKernAdvance(&font->stbFont, (int)font->kern, cp);
+		penx += (int)(kern * font->stbScale);
+	}
+	ChFontGlyphCacheEntry* glyph = ChFontGetCachedGlyph(font, cp);
+	ChFontBlitGlyph(canv, glyph, penx, peny, color, limit);
+	font->kern = (uint32_t)cp;
 #endif
 }
 
@@ -350,7 +532,21 @@ int64_t ChFontGetWidth(ChFont* font, char* string) {
 	}
 	return font_width;
 #else
-	return 8 * strlen(string);
+	if (!font)
+		return -1;
+	int64_t width = 0;
+	int prevCp = 0;
+	while (*string) {
+		int cp = (unsigned char)*string;
+		if (prevCp)
+			width += (int)(stbtt_GetCodepointKernAdvance(&font->stbFont, prevCp, cp) * font->stbScale);
+		int advance, lsb;
+		stbtt_GetCodepointHMetrics(&font->stbFont, cp, &advance, &lsb);
+		width += (int64_t)(advance * font->stbScale);
+		prevCp = cp;
+		string++;
+	}
+	return width;
 #endif
 }
 
@@ -382,7 +578,11 @@ int64_t ChFontGetWidthChar(ChFont* font, char c) {
 	}
 	return font_width;
 #else
-	return 8;
+	if (!font)
+		return -1;
+	int advance, lsb;
+	stbtt_GetCodepointHMetrics(&font->stbFont, (unsigned char)c, &advance, &lsb);
+	return (int64_t)(advance * font->stbScale);
 #endif
 }
 
@@ -416,7 +616,9 @@ int64_t ChFontGetHeight(ChFont* font, char* string) {
 	}
 	return font_height;
 #else
-	return 16;
+	if (!font)
+		return -1;
+	return font->lineHeight;
 #endif
 }
 
@@ -448,7 +650,9 @@ int64_t ChFontGetHeightChar(ChFont* font, char c) {
 	}
 	return font_h;
 #else
-	return 16;
+	if (!font)
+		return -1;
+	return font->lineHeight;
 #endif
 }
 
@@ -565,6 +769,24 @@ int ChFontDrawTextClipped(
 	}
 	return 0;
 #else
+	if (!font)
+		return 1;
+	if (!limit)
+		return 1;
+
+	int prevCp = 0;
+	while (*string) {
+		unsigned char cp = (unsigned char)*string;
+		if (prevCp) {
+			int kern = stbtt_GetCodepointKernAdvance(&font->stbFont, prevCp, cp);
+			penx += (int)(kern * font->stbScale);
+		}
+		ChFontGlyphCacheEntry* glyph = ChFontGetCachedGlyph(font, cp);
+		ChFontBlitGlyph(canv, glyph, penx, peny, color, limit);
+		penx += glyph->advance;
+		prevCp = cp;
+		string++;
+	}
 	return 0;
 #endif
 }
@@ -578,6 +800,9 @@ int ChFontClose(ChFont* font) {
 		return -1;
 	//FT_Done_Face(font->face);
 	//FT_Done_FreeType(font->lib);
+#ifndef _USE_FREETYPE
+	ChFontClearGlyphCache(font);
+#endif
 	_KeUnmapSharedMem(font->key);
 	free(font);
 	return 0;

--- a/Libs/Chitralekha/font.h
+++ b/Libs/Chitralekha/font.h
@@ -38,6 +38,7 @@
 #include "draw.h"
 #include <ft2build.h>
 #include FT_FREETYPE_H
+#include "stb_truetype.h"
 
 #ifdef __cplusplus
 XE_EXTERN{
@@ -51,6 +52,22 @@ XE_EXTERN{
 #define CALIBRI       "Calibri"
 #define FORTE         "Forte"
 #define CONSOLAS      "Consolas"
+
+#ifndef _USE_FREETYPE
+#define CH_FONT_GLYPH_CACHE_SIZE 256
+
+	/* caching the rasterized glyph + metrics here so we're not
+	 * re-rasterizing the same char every repaint, thats wasteful as hell --axiss */
+	typedef struct _ch_font_glyph_cache_entry_ {
+		uint8_t* bitmap;
+		int16_t width;
+		int16_t height;
+		int16_t xOffset;
+		int16_t yOffset;
+		int16_t advance;
+		uint8_t loaded;
+	} ChFontGlyphCacheEntry;
+#endif
 
 #ifdef ARCH_ARM64
 #define XENEVA_DEFAULT_FONT CALIBRI //FORTE
@@ -71,6 +88,16 @@ XE_EXTERN{
 		FT_Library lib;
 		FT_Face face;
 		FT_GlyphSlot slot;
+#else
+		/* fallback path for when freetype isnt built for the target (aa64/llvm rn).
+		 * reusing font->kern up above as the "previous codepoint" for kerning
+		 * lookups here too, didnt want another field just for that --axiss */
+		stbtt_fontinfo stbFont;
+		float stbScale;
+		int stbAscent;
+		int stbDescent;
+		int stbLineGap;
+		ChFontGlyphCacheEntry glyphCache[CH_FONT_GLYPH_CACHE_SIZE];
 #endif
 	}ChFont;
 

--- a/Process/Terminal/Makefile
+++ b/Process/Terminal/Makefile
@@ -26,7 +26,7 @@ ifeq ($(TOOLCHAIN), llvm)
 
     CXXFLAGS = -Wall -Wextra -ffreestanding -fno-stack-protector -fno-stack-check -fno-strict-aliasing \
                -O2 -fno-exceptions -fno-rtti $(LLVM_TARGET) \
-               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS -D_USE_FREETYPE -DTHEME_DEFAULT \
+               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS -DTHEME_DEFAULT \
                -Wno-error=incompatible-pointer-types -Wno-error=int-conversion \
                -Wno-implicit-function-declaration -Wno-c++11-narrowing \
                $(INCLUDES)
@@ -41,7 +41,7 @@ else
 
     CXXFLAGS = -Wall -Wextra -ffreestanding -fno-stack-protector -fno-stack-check -fno-strict-aliasing \
                -O2 -fPIE -fno-exceptions -fno-rtti \
-               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS -D_USE_FREETYPE -DTHEME_DEFAULT \
+               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS -DTHEME_DEFAULT \
                $(INCLUDES)
 endif
 

--- a/Scripts/Linux/build_and_run_qemu.sh
+++ b/Scripts/Linux/build_and_run_qemu.sh
@@ -1,62 +1,174 @@
 #!/bin/bash
 set -e
 
-# Check for build flags
-FORCE_LEGACY_BUILD=0
+# All-in-one build + image + QEMU test script for XenevaOS (AArch64).
+#
+# Usage: Scripts/Linux/build_and_run_qemu.sh [OPTIONS]
+#
+#   --llvm                  Build with the LLVM/Clang toolchain (default).
+#   --gcc                   Build with the GCC toolchain.
+#   --skip-build            Don't build BootAA64/KernelAA64/apps at all; just
+#                           reassemble images from whatever binaries already
+#                           exist on disk.
+#   --force-user-apps       Also rebuild userspace libs/apps and redeploy them
+#                           into Resources/resources/ before packing.
+#   --force-legacy-build    Reuse an existing initrd2.img instead of rebuilding it.
+#   --install-deps          Install required host packages for this distro.
+#   --initrd-size-mb=N      Override the auto-computed initrd2.img size.
+#   --headless              Run QEMU with -display none, bounded by a timeout,
+#                           instead of opening a GTK window. Known limitation:
+#                           the bootloader's screen-resolution menu only
+#                           accepts USB/virtio keyboard input, so a headless
+#                           run cannot reach kernel entry today — this flag
+#                           only prevents an unbounded hang.
+#   -h, --help              Show this help and exit.
+#
+# Known gap: x86_64 (Boot/Kernel) has no QEMU boot path here yet.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_DIR="$REPO_ROOT/Scripts/Linux"
+
+source "$SCRIPT_DIR/lib/enviorment_variables.sh"
+source "$SCRIPT_DIR/lib/functions.sh"
+
+TOOLCHAIN=llvm
+SKIP_BUILD=0
 BUILD_USER_APPS=0
+FORCE_LEGACY_BUILD=0
+INSTALL_DEPS=0
+HEADLESS=0
+INITRD_SIZE_MB=""
+
+print_help(){
+    printf "${STY_CYAN}"
+    sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    printf "${STY_RST}\n"
+}
 
 for arg in "$@"; do
-    if [ "$arg" == "--force-legacy-build" ]; then
-        FORCE_LEGACY_BUILD=1
-    elif [ "$arg" == "--force-user-apps" ]; then
-        BUILD_USER_APPS=1
+    case "$arg" in
+        --llvm) TOOLCHAIN=llvm ;;
+        --gcc) TOOLCHAIN=gcc ;;
+        --skip-build) SKIP_BUILD=1 ;;
+        --force-user-apps) BUILD_USER_APPS=1 ;;
+        --force-legacy-build) FORCE_LEGACY_BUILD=1 ;;
+        --install-deps) INSTALL_DEPS=1 ;;
+        --headless) HEADLESS=1 ;;
+        --initrd-size-mb=*) INITRD_SIZE_MB="${arg#--initrd-size-mb=}" ;;
+        -h|--help) print_help; exit 0 ;;
+        *)
+            printf "${STY_RED}[$0]: Unknown option \"$arg\".${STY_RST}\n"
+            print_help
+            exit 1
+        ;;
+    esac
+done
+
+cd "$REPO_ROOT"
+
+if [ "$INSTALL_DEPS" -eq 1 ]; then
+    source "$SCRIPT_DIR/lib/dist_determine.sh"
+    for function in ${print_os_group_id_functions[@]}; do
+        $function
+    done
+    pause
+    sudo_session
+    trap sudo_stop EXIT INT TERM
+    source "$SCRIPT_DIR/lib/distro/${OS_GROUP_ID}.sh" -d "--$TOOLCHAIN"
+fi
+
+# --- Preflight ---
+
+echo "[+] Checking required host tools..."
+MISSING_TOOLS=()
+for tool in mkfs.vfat mcopy mmd qemu-system-aarch64; do
+    command -v "$tool" >/dev/null 2>&1 || MISSING_TOOLS+=("$tool")
+done
+if [ "$TOOLCHAIN" == llvm ]; then
+    command -v clang >/dev/null 2>&1 || MISSING_TOOLS+=("clang")
+else
+    command -v aarch64-linux-gnu-gcc >/dev/null 2>&1 || MISSING_TOOLS+=("aarch64-linux-gnu-gcc")
+fi
+if [ "${#MISSING_TOOLS[@]}" -gt 0 ]; then
+    printf "${STY_RED}[$0]: Missing required tools: ${MISSING_TOOLS[*]}${STY_RST}\n"
+    printf "${STY_YELLOW}[$0]: Run with --install-deps, or install them manually.${STY_RST}\n"
+    exit 1
+fi
+
+if [ "$SKIP_BUILD" -eq 0 ] && [ ! -d "$REPO_ROOT/gnu-efi" ]; then
+    printf "${STY_RED}[$0]: gnu-efi not found at repo-root/gnu-efi.${STY_RST}\n"
+    printf "${STY_YELLOW}[$0]: Clone it first: git clone https://github.com/vathpela/gnu-efi.git${STY_RST}\n"
+    exit 1
+fi
+
+resolve_qemu_firmware(){
+    local candidates=(
+        "${XENEVA_QEMU_FIRMWARE:-}"
+        "/usr/share/edk2/aarch64/QEMU_EFI.fd"
+        "/usr/share/qemu-efi-aarch64/QEMU_EFI.fd"
+    )
+    for candidate in "${candidates[@]}"; do
+        if [ -n "$candidate" ] && [ -f "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+QEMU_FIRMWARE="$(resolve_qemu_firmware)" || {
+    printf "${STY_RED}[$0]: Could not find AArch64 UEFI firmware (QEMU_EFI.fd).${STY_RST}\n"
+    printf "${STY_YELLOW}[$0]: Install it (Arch: edk2-aarch64, Debian/Ubuntu: qemu-efi-aarch64),\n"
+    printf "    or point XENEVA_QEMU_FIRMWARE at the .fd file.${STY_RST}\n"
+    exit 1
+}
+echo "[+] Using QEMU firmware: $QEMU_FIRMWARE"
+
+# --- Build ---
+
+if [ "$SKIP_BUILD" -eq 0 ]; then
+    echo "[+] Building bootloader + kernel (+ apps if requested) with $TOOLCHAIN..."
+    export BUILD_USER_APPS
+    pushd "$SCRIPT_DIR" >/dev/null
+    if [ "$TOOLCHAIN" == llvm ]; then
+        source ./lib/llvm.sh
+    else
+        source ./lib/gcc.sh
+    fi
+    popd >/dev/null
+else
+    echo "[+] --skip-build passed, reusing existing build artifacts."
+fi
+
+for artifact in "BootAA64/Build/EFI/BOOT/BOOTAA64.efi" "KernelAA64/KernelAA64.exe"; do
+    if [ ! -f "$REPO_ROOT/$artifact" ]; then
+        printf "${STY_RED}[$0]: Expected build artifact missing: $artifact${STY_RST}\n"
+        printf "${STY_YELLOW}[$0]: Run without --skip-build, or build it manually first.${STY_RST}\n"
+        exit 1
     fi
 done
 
-if [ "$BUILD_USER_APPS" -eq 1 ]; then
-    echo "[+] Rebuilding Libraries and User Applications..."
-    
-    echo "    [-] Building XEClib (clang/LLVM)..."
-    make -C Libs/XEClib clean
-    make -C Libs/XEClib llvm
-    
-    echo "    [-] Building Chitralekha (clang/LLVM)..."
-    make -C Libs/Chitralekha clean
-    make -C Libs/Chitralekha llvm
-    
-    APPS=(
-        "Init"
-        "DeodhaiXR"
-        "Terminal"
-        "Namdapha"
-        "XELnch"
-        "DeodhaiAudio"
-        "Calender"
-        "Calculator"
-        "AudioPlayer"
-        "Files"
-        "Control"
-    )
-    
-    for app in "${APPS[@]}"; do
-        echo "    [-] Building $app (clang/LLVM)..."
-        make -C Process/$app clean
-        make -C Process/$app llvm
-    done
-    
-    echo "[+] Deploying newly built binaries to Resources/resources/..."
-    cp -f Process/Init/init.exe Resources/resources/
-    cp -f Process/DeodhaiXR/deodxr.exe Resources/resources/
-    cp -f Process/Terminal/term.exe Resources/resources/
-    cp -f Process/Namdapha/nmdapha.exe Resources/resources/
-    cp -f Process/XELnch/xelnch.exe Resources/resources/
-    cp -f Process/DeodhaiAudio/deoaud.exe Resources/resources/
-    cp -f Process/Calender/calendr.exe Resources/resources/
-    cp -f Process/Calculator/calc.exe Resources/resources/
-    cp -f Process/AudioPlayer/audplr.exe Resources/resources/
-    cp -f Process/Files/file.exe Resources/resources/
-    cp -f Process/Control/ctrl.exe Resources/resources/
+# --- Assemble initrd2.img ---
+
+if [ "$FORCE_LEGACY_BUILD" -eq 0 ]; then
+    if [ -n "$INITRD_SIZE_MB" ]; then
+        initrd_size_mb="$INITRD_SIZE_MB"
+    else
+        resources_mb=$(du -sm Resources/resources | cut -f1)
+        computed_mb=$(( (resources_mb * 3 + 1) / 2 ))  # ceil(resources_mb * 1.5)
+        initrd_size_mb=$(( computed_mb > 96 ? computed_mb : 96 ))
+    fi
+    echo "[+] Creating ${initrd_size_mb}MB FAT32 initrd2.img and packing resources..."
+    dd if=/dev/zero of=initrd2.img bs=1M count="$initrd_size_mb"
+    mkfs.vfat -F 32 initrd2.img
+    mcopy -o -s -i initrd2.img Resources/resources/* ::/
+    mcopy -o -i initrd2.img Process/Init/init.exe ::/init.exe
+else
+    echo "[+] Found pre-built initrd2.img, skipping manual creation."
+    echo "    (Omit --force-legacy-build to rebuild it.)"
 fi
+
+# --- Assemble fat.img (ESP) ---
 
 echo "[+] Creating 512MB FAT32 image..."
 dd if=/dev/zero of=fat.img bs=1M count=512
@@ -67,40 +179,40 @@ mmd -i fat.img ::/EFI
 mmd -i fat.img ::/EFI/BOOT
 mmd -i fat.img ::/EFI/XENEVA
 
-# [Note: The default script will always build initrd2.img and pack resources.
-# Using a pre-built legacy initrd2.img is NOT RECOMMENDED, but can be forced
-# by passing the --force-legacy-build flag.
-# Example Directory Structure:
-#   XenevaOS/
-#   ├── KernelAA64/
-#   ├── BootAA64/
-#   ├── Scripts/
-#   └── initrd2.img   <-- Place it exactly here
-# ]
-if [ "$FORCE_LEGACY_BUILD" -eq 0 ]; then
-    echo "[+] Creating 64MB FAT32 initrd2.img and packing resources..."
-    dd if=/dev/zero of=initrd2.img bs=1M count=64
-    mkfs.vfat -F 32 initrd2.img
-    mcopy -o -i initrd2.img Resources/resources/* ::/
-    mcopy -o -i initrd2.img Process/Init/init.exe ::/init.exe
-else
-    echo "[+] Found pre-built initrd2.img, skipping manual creation."
-    echo "    (Use --force-manual-build flag to override)"
-fi
-
 mcopy -o -i fat.img BootAA64/Build/EFI/BOOT/BOOTAA64.efi ::/EFI/BOOT/BOOTAA64.EFI
 mcopy -o -i fat.img KernelAA64/KernelAA64.exe ::/EFI/XENEVA/xnkrnl.exe
 mcopy -o -i fat.img initrd2.img ::/initrd2.img
 
+# --- Launch QEMU ---
+
 echo "[+] Image ready! Booting QEMU..."
-qemu-system-aarch64 -machine virt,gic-version=2,highmem=off \
-    -cpu cortex-a57 -m 1024M \
-    -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
-    -drive file=fat.img,format=raw,if=virtio \
-    -device ramfb \
-    -device virtio-keyboard-pci \
-    -device virtio-tablet-pci \
-    -device usb-ehci \
-    -device usb-kbd \
-    -serial stdio \
-    -display gtk,zoom-to-fit=on
+QEMU_ARGS=(
+    -machine virt,gic-version=2,highmem=off
+    -cpu cortex-a72
+    -m 1024M
+    -bios "$QEMU_FIRMWARE"
+    -drive file=fat.img,format=raw,if=virtio
+    -device ramfb
+    -device virtio-keyboard-pci
+    -device virtio-tablet-pci
+    -device usb-ehci
+    -device usb-kbd
+    -serial stdio
+)
+
+if [ "$HEADLESS" -eq 1 ]; then
+    QEMU_ARGS+=(-display none -no-reboot)
+
+    # the bootloader's screen-resolution menu (XEGetScreenResolutionMode in
+    # BootAA64/xnldr.cpp) always blocks on a keystroke before handing off to
+    # the kernel, and it only listens to the emulated USB/virtio keyboard —
+    # I tried both a QMP send-key and feeding input over the -serial stdio
+    # UART and neither reached it, so headless can't get to kernel entry yet.
+    # this still bounds the run with a timeout instead of hanging forever,
+    # which is the main point for CI/automation. actually skipping the menu
+    # non-interactively needs a bootloader-side fix, out of scope here --axiss
+    timeout "${QEMU_TIMEOUT:-120}" qemu-system-aarch64 "${QEMU_ARGS[@]}"
+else
+    QEMU_ARGS+=(-display gtk,zoom-to-fit=on)
+    qemu-system-aarch64 "${QEMU_ARGS[@]}"
+fi

--- a/Scripts/Linux/lib/distro/arch.sh
+++ b/Scripts/Linux/lib/distro/arch.sh
@@ -20,3 +20,30 @@ fi
 if [[ -z "${PACMAN_AUTH:-}" ]]; then
   export PACMAN_AUTH="sudo"
 fi
+
+# update the system
+v sudo pacman -Syu --noconfirm
+
+# common for both llvm and gcc
+v sudo pacman -S --needed --noconfirm make
+v sudo pacman -S --needed --noconfirm dosfstools
+v sudo pacman -S --needed --noconfirm mtools
+v sudo pacman -S --needed --noconfirm qemu-system-aarch64
+v sudo pacman -S --needed --noconfirm edk2-aarch64
+
+case $2 in
+	--llvm|llvm)
+		v sudo pacman -S --needed --noconfirm clang
+		v sudo pacman -S --needed --noconfirm lld
+		v sudo pacman -S --needed --noconfirm llvm
+	;;
+	--gcc|gcc)
+		v sudo pacman -S --needed --noconfirm aarch64-linux-gnu-gcc
+		v sudo pacman -S --needed --noconfirm aarch64-linux-gnu-binutils
+		cd ../..
+		v git clone https://github.com/vathpela/gnu-efi
+	;;
+	*)
+		printf "${STY_RED}Plese choose from llvm and gcc. Aborting ...${STY_RST}\n"
+	;;
+esac

--- a/Scripts/Linux/lib/functions.sh
+++ b/Scripts/Linux/lib/functions.sh
@@ -108,7 +108,7 @@ function sudo_stop(){
 # Help output for the scipt and information on how to use it
 function show_help(){
     printf "${STY_CYAN}
-Script for checking dependency and ruuning XenevaOS with llvm.
+Script for checking dependencies for XenevaOS.
 
 ${STY_UNDERLINE}Usage:${STY_RST}${STY_CYAN} $0 [OPTION] <sub-option>
 
@@ -120,11 +120,13 @@ ${STY_UNDERLINE}Options:${STY_RST}${STY_CYAN}
         --llvm, llvm      install dependencis for llvm build.
         --gcc, gcc        install dependencies for gcc build.
 
---llvm, llvm              compile the XenevaOS for arm(for now) using llvm toolchain (needs llvm deps)
---gcc, gcc                compile the XenevaOS for arm(for now) using gcc toolchain (needs gcc deps)
+--llvm, llvm              ${STY_YELLOW}deprecated${STY_CYAN}: hands off to ./build_and_run_qemu.sh --llvm
+--gcc, gcc                ${STY_YELLOW}deprecated${STY_CYAN}: hands off to ./build_and_run_qemu.sh --gcc
 	both gcc and llvm supports sub option for:
-		--build, build	  builds initrd2 image for XenevaOS
+		--build, build	  also (re)builds initrd2.img, not just the ESP image
 
+${STY_UNDERLINE}For building and booting XenevaOS in QEMU, use:${STY_RST}${STY_CYAN}
+    ./build_and_run_qemu.sh --help
 
 ${STY_BOLD}${STY_CYAN}Access https://github.com/manaskamal/XenevaOS/blob/master/Docs/Index.md${STY_RST} ${STY_BOLD}${STY_CYAN}for documentation about XenevaOS.${STY_RST}
 "

--- a/Scripts/Linux/lib/gcc.sh
+++ b/Scripts/Linux/lib/gcc.sh
@@ -1,10 +1,63 @@
 #! This script is not meant for execution, so no need for execution permission or shebang.
 
+printf "${STY_CYAN}compiling Xeneva for AArch64 using GCC.${STY_RST}\n"
 
-printf "${STY_CYAN}compiling Xeneva for arm using gcc.${STY_RST}\n"
-cd ../../BootAA64
-make clean
-make
+# The EFI bootloader needs the gnu-efi sources (headers + static libs) checked
+# out next to the repository root, for both toolchains. See
+# Docs/BuildInstructions(Linux).md.
+if [ ! -d ../../gnu-efi ]; then
+    printf "${STY_RED}[gcc] gnu-efi not found at repo-root/gnu-efi.${STY_RST}\n"
+    printf "${STY_YELLOW}[gcc] Clone it first: git clone https://github.com/vathpela/gnu-efi.git${STY_RST}\n"
+    exit 1
+fi
 
-cd ../KernelAA64
-make clean make
+# the llvm path only needs gnu-efi's headers, but the gcc path also links
+# against its compiled crt0/libgnuefi/libefi, so I have to actually build it
+# for aarch64 first here (same as .github/workflows/build-check.yml does) --axiss
+if [ ! -f ../../gnu-efi/aarch64/gnuefi/crt0-efi-aarch64.o ]; then
+    printf "${STY_CYAN}[gcc] Building gnu-efi for aarch64...${STY_RST}\n"
+    ( cd ../../gnu-efi && make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu- )
+fi
+
+# every Makefile in this build (BootAA64, KernelAA64, Libs/*, Process/*)
+# lists its "llvm:" rule before "all:", so a bare `make` with no target
+# silently defaults to llvm: and TOOLCHAIN ?= gcc never gets exercised.
+# found this the hard way. passing `make all` explicitly sidesteps it
+# without me having to reorder rules in 15 Makefiles --axiss
+
+# EFI bootloader
+( cd ../../BootAA64 && make clean && make all )
+
+# AArch64 kernel
+( cd ../../KernelAA64 && make clean && make all )
+
+if [ "${BUILD_USER_APPS:-0}" -eq 1 ]; then
+    # Userspace C++ runtime + graphics library
+    ( cd ../../Libs/XEClib && make clean && make all )
+    ( cd ../../Libs/Chitralekha && make clean && make all )
+
+    # All AArch64 user-space applications
+    APPS=(
+        Init DeodhaiXR Terminal Namdapha XELnch DeodhaiAudio
+        Calender Calculator AudioPlayer Files Control
+    )
+    for app in "${APPS[@]}"; do
+        ( cd "../../Process/$app" && make clean && make all )
+    done
+
+    # Deploy the freshly built application binaries into the resources tree so
+    # they get packed into initrd2.img by the caller's resource-copy step.
+    cp -f ../../Process/Init/init.exe            ../../Resources/resources/
+    cp -f ../../Process/DeodhaiXR/deodxr.exe     ../../Resources/resources/
+    cp -f ../../Process/Terminal/term.exe         ../../Resources/resources/
+    cp -f ../../Process/Namdapha/nmdapha.exe      ../../Resources/resources/
+    cp -f ../../Process/XELnch/xelnch.exe         ../../Resources/resources/
+    cp -f ../../Process/DeodhaiAudio/deoaud.exe   ../../Resources/resources/
+    cp -f ../../Process/Calender/calendr.exe      ../../Resources/resources/
+    cp -f ../../Process/Calculator/calc.exe       ../../Resources/resources/
+    cp -f ../../Process/AudioPlayer/audplr.exe    ../../Resources/resources/
+    cp -f ../../Process/Files/file.exe            ../../Resources/resources/
+    cp -f ../../Process/Control/ctrl.exe          ../../Resources/resources/
+fi
+
+printf "${STY_GREEN}[gcc] AArch64 GCC build complete.${STY_RST}\n"

--- a/Scripts/Linux/lib/llvm.sh
+++ b/Scripts/Linux/lib/llvm.sh
@@ -16,31 +16,33 @@ fi
 # AArch64 kernel
 ( cd ../../KernelAA64 && make clean && make llvm )
 
-# Userspace C++ runtime + graphics library
-( cd ../../Libs/XEClib && make clean && make llvm )
-( cd ../../Libs/Chitralekha && make clean && make llvm )
+if [ "${BUILD_USER_APPS:-0}" -eq 1 ]; then
+    # Userspace C++ runtime + graphics library
+    ( cd ../../Libs/XEClib && make clean && make llvm )
+    ( cd ../../Libs/Chitralekha && make clean && make llvm )
 
-# All AArch64 user-space applications
-APPS=(
-    Init DeodhaiXR Terminal Namdapha XELnch DeodhaiAudio
-    Calender Calculator AudioPlayer Files Control
-)
-for app in "${APPS[@]}"; do
-    ( cd "../../Process/$app" && make clean && make llvm )
-done
+    # All AArch64 user-space applications
+    APPS=(
+        Init DeodhaiXR Terminal Namdapha XELnch DeodhaiAudio
+        Calender Calculator AudioPlayer Files Control
+    )
+    for app in "${APPS[@]}"; do
+        ( cd "../../Process/$app" && make clean && make llvm )
+    done
 
-# Deploy the freshly built application binaries into the resources tree so
-# they get packed into initrd2.img by the caller's resource-copy step.
-cp -f ../../Process/Init/init.exe            ../../Resources/resources/
-cp -f ../../Process/DeodhaiXR/deodxr.exe     ../../Resources/resources/
-cp -f ../../Process/Terminal/term.exe         ../../Resources/resources/
-cp -f ../../Process/Namdapha/nmdapha.exe      ../../Resources/resources/
-cp -f ../../Process/XELnch/xelnch.exe         ../../Resources/resources/
-cp -f ../../Process/DeodhaiAudio/deoaud.exe   ../../Resources/resources/
-cp -f ../../Process/Calender/calendr.exe      ../../Resources/resources/
-cp -f ../../Process/Calculator/calc.exe       ../../Resources/resources/
-cp -f ../../Process/AudioPlayer/audplr.exe    ../../Resources/resources/
-cp -f ../../Process/Files/file.exe            ../../Resources/resources/
-cp -f ../../Process/Control/ctrl.exe          ../../Resources/resources/
+    # Deploy the freshly built application binaries into the resources tree so
+    # they get packed into initrd2.img by the caller's resource-copy step.
+    cp -f ../../Process/Init/init.exe            ../../Resources/resources/
+    cp -f ../../Process/DeodhaiXR/deodxr.exe     ../../Resources/resources/
+    cp -f ../../Process/Terminal/term.exe         ../../Resources/resources/
+    cp -f ../../Process/Namdapha/nmdapha.exe      ../../Resources/resources/
+    cp -f ../../Process/XELnch/xelnch.exe         ../../Resources/resources/
+    cp -f ../../Process/DeodhaiAudio/deoaud.exe   ../../Resources/resources/
+    cp -f ../../Process/Calender/calendr.exe      ../../Resources/resources/
+    cp -f ../../Process/Calculator/calc.exe       ../../Resources/resources/
+    cp -f ../../Process/AudioPlayer/audplr.exe    ../../Resources/resources/
+    cp -f ../../Process/Files/file.exe            ../../Resources/resources/
+    cp -f ../../Process/Control/ctrl.exe          ../../Resources/resources/
+fi
 
 printf "${STY_GREEN}[llvm] AArch64 LLVM/Clang build complete.${STY_RST}\n"

--- a/Scripts/Linux/manager.sh
+++ b/Scripts/Linux/manager.sh
@@ -25,48 +25,22 @@ case $1 in
         source ./lib/distro/${OS_GROUP_ID}.sh
     ;;
     --llvm|--gcc|llvm|gcc)
-        echo "[+] Creating 512MB FAT32 image..."
-        cd ../..
-        dd if=/dev/zero of=fat.img bs=1M count=512
-        mkfs.vfat fat.img
-        echo "[+] Copying EFI Bootloader and Kernel via mtools..."
-        mmd -i fat.img ::/EFI
-        mmd -i fat.img ::/EFI/BOOT
-        mmd -i fat.img ::/EFI/XENEVA
-        cd Scripts/Linux
+        printf "${STY_YELLOW}[$0]: This subcommand is deprecated. build_and_run_qemu.sh is now the\n"
+        printf "single build+image+QEMU script and builds the bootloader/kernel itself.\n"
+        printf "Handing off to ./build_and_run_qemu.sh ...${STY_RST}\n"
+        # manager.sh used to always rebuild userspace apps unconditionally
+        # (via lib/llvm.sh), and its "build" sub-arg meant "also (re)build
+        # initrd2.img" — the opposite of no-arg. translating both to the new
+        # script's flags, which default to rebuilding the initrd every run --axiss
+        NEW_ARGS=(--force-user-apps)
         case $1 in
-            --llvm|llvm)
-                source ./lib/llvm.sh
-            ;;
-            --gcc|gcc)
-                source ./lib/gcc.sh
-            ;;
+            --llvm|llvm) NEW_ARGS+=(--llvm) ;;
+            --gcc|gcc) NEW_ARGS+=(--gcc) ;;
         esac
-        if [[ $2 =~ ^(--build|build)$ ]]; then
-            echo "[+] Creating 64MB FAT32 initrd2.img and packing resources..."
-            cd ../..
-            dd if=/dev/zero of=initrd2.img bs=1M count=64
-            mkfs.vfat -F 32 initrd2.img
-            mcopy -o -i initrd2.img Resources/resources/* ::/
-            mcopy -o -i initrd2.img Process/Init/init.exe ::/init.exe
+        if [[ ! $2 =~ ^(--build|build)$ ]]; then
+            NEW_ARGS+=(--force-legacy-build)
         fi
-        mcopy -o -i fat.img BootAA64/Build/EFI/BOOT/BOOTAA64.efi ::/EFI/BOOT/BOOTAA64.EFI
-        mcopy -o -i fat.img KernelAA64/KernelAA64.exe ::/EFI/XENEVA/xnkrnl.exe
-        mcopy -o -i fat.img initrd2.img ::/initrd2.img
-        echo "[+] Image ready! Booting QEMU..."
-        qemu-system-aarch64 -machine virt,gic-version=2,highmem=off \
-            -cpu cortex-a72 \
-            -m 1024M \
-            -bios /usr/share/qemu-efi-aarch64/QEMU_EFI.fd \
-            -drive file=fat.img,format=raw,if=virtio \
-            -device ramfb \
-            -device virtio-keyboard-pci \
-            -device virtio-tablet-pci \
-            -display gtk \
-            -device usb-ehci \
-            -device usb-kbd \
-            -serial stdio 
-            # -d guest_errors,unzip,trace:virtio_gpu
+        exec ./build_and_run_qemu.sh "${NEW_ARGS[@]}"
     ;;
     *)printf "${STY_RED}Unknown subcommand \"$1\".${STY_RST}\n";show_help;exit 1;;
 esac

--- a/Tests/tlsf_stress.c
+++ b/Tests/tlsf_stress.c
@@ -1,0 +1,82 @@
+#include <Mm/tlsf.h>
+#include <stdint.h>
+#include <string.h>
+
+extern int puts(const char* string);
+
+#define HEAP_SIZE (2U * 1024U * 1024U)
+#define SLOT_COUNT 256
+#define ITERATIONS 50000
+
+static _Alignas(TLSF_ALIGN_SIZE) unsigned char heap[HEAP_SIZE];
+
+typedef struct allocation {
+	unsigned char* ptr;
+	size_t size;
+	unsigned char pattern;
+} allocation_t;
+
+static uint32_t random_state = 0x58454e45U;
+
+static uint32_t next_random(void) {
+	random_state ^= random_state << 13;
+	random_state ^= random_state >> 17;
+	random_state ^= random_state << 5;
+	return random_state;
+}
+
+static int verify(const allocation_t* allocation) {
+	for (size_t i = 0; i < allocation->size; ++i) {
+		if (allocation->ptr[i] != allocation->pattern)
+			return -1;
+	}
+	return 0;
+}
+
+int main(void) {
+	tlsf_pool_t* pool = tlsf_create();
+	allocation_t slots[SLOT_COUNT] = {0};
+	if (!pool || tlsf_add_memory(pool, heap, sizeof(heap)) != 0)
+		return 1;
+
+	for (unsigned int iteration = 0; iteration < ITERATIONS; ++iteration) {
+		unsigned int slot = next_random() % SLOT_COUNT;
+		allocation_t* allocation = &slots[slot];
+		if (allocation->ptr && verify(allocation) != 0)
+			return 2;
+
+		uint32_t operation = next_random() % 3;
+		if (!allocation->ptr) {
+			size_t size = 1 + (next_random() % 8192);
+			allocation->ptr = tlsf_malloc(pool, size);
+			if (!allocation->ptr)
+				continue;
+			allocation->size = size;
+			allocation->pattern = (unsigned char)(slot + 1);
+			memset(allocation->ptr, allocation->pattern, size);
+		} else if (operation == 0) {
+			tlsf_free(pool, allocation->ptr);
+			memset(allocation, 0, sizeof(*allocation));
+		} else {
+			size_t old_size = allocation->size;
+			size_t new_size = 1 + (next_random() % 12288);
+			unsigned char* resized = tlsf_realloc(pool, allocation->ptr, new_size);
+			if (!resized)
+				continue;
+			allocation->ptr = resized;
+			allocation->size = new_size;
+			if (verify(&(allocation_t){resized,
+				old_size < new_size ? old_size : new_size,
+				allocation->pattern}) != 0)
+				return 3;
+			memset(resized, allocation->pattern, new_size);
+		}
+	}
+
+	for (unsigned int i = 0; i < SLOT_COUNT; ++i) {
+		if (slots[i].ptr && verify(&slots[i]) != 0)
+			return 4;
+	}
+	puts("tlsf stress: ok");
+	return 0;
+}


### PR DESCRIPTION
## Changes
This pull request introduces several enhancements and fixes across the bootloader, kernel interface, memory management, and documentation. The most significant changes are the addition of a physical direct map to the bootloader and kernel handoff, improvements to the physical memory manager interface, and important clarifications in the documentation. There are also build system fixes and small improvements to the virtual disk and memory allocation subsystems.

### Bootloader and Kernel Interface Improvements

* Added a physical direct map to the bootloader (`XEPagingInstallPhysicalDirectMap`) and passed its base and size to the kernel via the `KERNEL_BOOT_INFO` structure, ensuring the kernel is aware of the direct-mapped physical memory region. (`BootAA64/paging.cpp`, `BootAA64/paging.h`, `BootAA64/xnldr.cpp`, `BaseHdr/aurora.h`) [[1]](diffhunk://#diff-542f4c1114819c35c225fa800505e449b109d552d77b33f0cd7632ad05487221R161-R184) [[2]](diffhunk://#diff-e31cd6ecf28dd504aaa406ff9fa903a0d4b952d5861d365fdff55b3648845805L44-R45) [[3]](diffhunk://#diff-e31cd6ecf28dd504aaa406ff9fa903a0d4b952d5861d365fdff55b3648845805R63) [[4]](diffhunk://#diff-b51fd6d21949f41c3df1262782f95968c52be80e5382894c29fe2be8e7592a7cR594) [[5]](diffhunk://#diff-defdf0f0fd63b2e2d1c73b5f868178693232b2df52090a50afdcc2876c7c1c5fR134-R137)
* Unified the bootloader and kernel handoff structure by using `KERNEL_BOOT_INFO` as the single definition for both, reducing fragmentation and potential mismatches. (`BootAA64/xnldr.h`)
* Updated bootloader field names to match kernel expectations (e.g., `allocated_stack`, `psf_font_data`, `apcode`). (`BootAA64/xnldr.cpp`) [[1]](diffhunk://#diff-b51fd6d21949f41c3df1262782f95968c52be80e5382894c29fe2be8e7592a7cL601-R609) [[2]](diffhunk://#diff-b51fd6d21949f41c3df1262782f95968c52be80e5382894c29fe2be8e7592a7cL618-R629)

### Memory Management Enhancements

* Refactored the physical memory manager interface for ARM64 to expose more statistics and management functions, and introduced the `AuPmmStats` structure for tracking memory usage. (`BaseHdr/Mm/pmmngr.h`)
* Improved the TLSF allocator to use a 64-bit first-level bitmap and corrected the index count for better scalability on 64-bit systems. (`BaseHdr/Mm/tlsf.h`) [[1]](diffhunk://#diff-c62850c9e53a3f150427580c9479b03a344fd8f253c7aa20bb55d5d9a5020733L50-R50) [[2]](diffhunk://#diff-c62850c9e53a3f150427580c9479b03a344fd8f253c7aa20bb55d5d9a5020733L85-R84)

### Virtual Disk and Device Support

* Added a `Flush` function pointer to the `AuVDisk` structure for driver-level write-cache flush support, and new API functions to flush single or all registered disks. (`BaseHdr/Fs/vdisk.h`) [[1]](diffhunk://#diff-36d3c735defc8f780e399428d7ec5aa625136ee38b6896e0c63ff37cc6713447R59-R67) [[2]](diffhunk://#diff-36d3c735defc8f780e399428d7ec5aa625136ee38b6896e0c63ff37cc6713447R115) [[3]](diffhunk://#diff-36d3c735defc8f780e399428d7ec5aa625136ee38b6896e0c63ff37cc6713447R199-R213)

### Build System and Toolchain Fixes

* Updated the ARM64 bootloader linker invocation to allow multiple symbol definitions (resolving `memset`/`memcpy` conflicts) and to use the correct PE format for EFI binaries. (`BootAA64/Makefile`)
* Added VSCode debug launch configurations for both MicroPython emulator and native Python. (`.vscode/launch.json`)

### Documentation Updates

* Clarified the behavior of the QEMU build and boot process, including the handling of `__TARGET_BOARD_QEMU_VIRT__` and the initrd image sizing, for both Linux and Windows build instructions. (`Docs/BuildInstructions(Linux).md`, `Docs/BuildInstructions(ARM64).md`) [[1]](diffhunk://#diff-284808d4eb8e1c608cfd08f3710b790b958d1fd24f4a340d6430d40782972cb6L39-R39) [[2]](diffhunk://#diff-bdd32dedb90ea47db6b75e25a3da41ad5e1d64ab6f1029c4775bcc81d496b04eR19)

## Compatibility
- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [ ] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.

## Related
R&D.
