### PR TITLE
fix(aarch64): virtio-net ping and --term framebuffer TTY

### DIFF
--- a/KernelAA64/Board/Virt/virt.c
+++ b/KernelAA64/Board/Virt/virt.c
@@ -97,10 +97,9 @@ void AuVirtIOInputInitialize() {
 						AuVirtioTabletInitialize(address);
 					}
 				}
-				if (vendID == 0x1AF4 && devID == 0x1041) {
-					/* initialize network device */
+				if (vendID == 0x1AF4 && (devID == 0x1041 || devID == 0x1000)) {
 					numVirtIODevice++;
-					//AuVirtioNetInitialize(address);
+					AuVirtioNetInitialize(address);
 				}
 			}
 		}

--- a/KernelAA64/Drivers/virtionet.c
+++ b/KernelAA64/Drivers/virtionet.c
@@ -33,24 +33,39 @@
 #include <Hal/AA64/aa64lowlevel.h>
 #include <Hal/AA64/gic.h>
 #include <Fs/Dev/devinput.h>
+#include <Fs/vfs.h>
 #include <Drivers/virtio.h>
 #include <Drivers/uart.h>
 #include <Mm/pmmngr.h>
+#include <Mm/kmalloc.h>
 #include <aucon.h>
 #include <Mm/vmmngr.h>
 #include <Hal/AA64/sched.h>
+#include <Net/aunet.h>
+#include <Net/ethernet.h>
+#include <string.h>
 
 #define VIRTIO_F_VERSION_1		  (1ull << 32)
 #define RX_BUFFER_COUNT			  8
+#define TX_BUFFER_COUNT			  8
+#define TX_BUFFER_SIZE			  2048
 #define RX_BUFFER_SIZE			  2048
 #define VIRTIO_PCI_CAP_ID		  0x09
 #define VIRTIO_PCI_CAP_COMMON_CFG 1
 #define VIRTIO_PCI_CAP_DEVICE_CFG 4
+#define MAKE_IP(a, b, c, d) \
+	((uint32_t)(d) << 24 | (uint32_t)(c) << 16 | (uint32_t)(b) << 8 | (uint32_t)(a))
 
 struct VirtioQueue* rxqueue;
 struct VirtioQueue* txqueue;
 volatile uint8_t* notifyBase;
 uint32_t notifyOffMultiplier;
+static virtio_net_hdr_t* rx_hdrs;
+static uint16_t rx_index;
+static uint16_t tx_index;
+static struct VirtioCommonCfg* _cfg;
+static AuVFSNode* nic;
+static AuNetworkDevice* ndev;
 
 /**
  * VirtioNetCfg -- virtio net configuration
@@ -77,7 +92,23 @@ struct VirtioNetCfg {
  * passed by system
  */
 void AuVirtioNetHandler(int spiNum) {
-	UARTDebugOut("[aurora]: virtio-net interrupt occured++ \r\n");
+	uint16_t them;
+	(void)spiNum;
+	if (!rxqueue)
+		return;
+	them = rxqueue->used.index;
+	for (; rx_index != them; rx_index++) {
+		uint32_t used_slot = rx_index % RX_BUFFER_COUNT;
+		uint32_t buf_id = rxqueue->used.ring[used_slot].index % RX_BUFFER_COUNT;
+		uint8_t* buffer = (uint8_t*)rx_hdrs + buf_id * RX_BUFFER_SIZE;
+		void* eth = (uint8_t*)buffer + sizeof(virtio_net_hdr_t);
+		if (nic)
+			AuEthernetHandle(eth, rxqueue->used.ring[used_slot].length, nic);
+		rxqueue->available.ring[rxqueue->available.index % RX_BUFFER_COUNT] = buf_id;
+		rxqueue->available.index++;
+		dsb_ish();
+		isb_flush();
+	}
 }
 /**
  * @brief AuVirtioNetReset -- reset the net device
@@ -152,11 +183,15 @@ void AuVirtioNetRxinitialize(struct VirtioCommonCfg* common) {
 	common->QueueSelect = 0;
 	isb_flush();
 	dsb_ish();
+	common->QueueSize = RX_BUFFER_COUNT;
+	isb_flush();
+	dsb_ish();
 	uint16_t qsize = common->QueueSize;
 	UARTDebugOut("[aurora]: rx queue size : %d \r\n", qsize);
 	uint64_t queuePhys = (uint64_t)
-		AuPmmngrAllocPage(AURORA_PAGE_NORMAL); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
-	rxqueue = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
+		AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+	rxqueue = (struct VirtioQueue*)P2V(queuePhys);
+	memset(rxqueue, 0, sizeof(*rxqueue));
 
 	common->QueueDesc = queuePhys;
 	common->QueueAvail = (queuePhys) + OFFSETOF(struct VirtioQueue, available);
@@ -173,6 +208,7 @@ void AuVirtioNetRxinitialize(struct VirtioCommonCfg* common) {
 		UARTDebugOut("[aurora]: unable to allocate contiguous virtio RX buffer\r\n");
 		return;
 	}
+	rx_hdrs = (virtio_net_hdr_t*)P2V(rxbuff);
 	for (int i = 0; i < RX_BUFFER_COUNT; i++) {
 		rxqueue->buffers[i].Addr = rxbuff + (i * 2048);
 		rxqueue->buffers[i].Length = RX_BUFFER_SIZE;
@@ -195,11 +231,15 @@ void AuVirtioNetTxinitialize(struct VirtioCommonCfg* common) {
 	common->QueueSelect = 1;
 	isb_flush();
 	dsb_ish();
+	common->QueueSize = TX_BUFFER_COUNT;
+	isb_flush();
+	dsb_ish();
 	uint16_t qsize = common->QueueSize;
 	UARTDebugOut("[aurora]: tx queue size : %d \r\n", qsize);
 	uint64_t queuePhys = (uint64_t)
-		AuPmmngrAllocPage(AURORA_PAGE_NORMAL); //AuPmmngrAllocBlocks(((sizeof(struct VirtioQueue) * queueSz)) / 0x1000);
-	txqueue = (struct VirtioQueue*)AuMapMMIO(queuePhys, 1);
+		AuPmmngrAllocPage(AURORA_PAGE_NORMAL);
+	txqueue = (struct VirtioQueue*)P2V(queuePhys);
+	memset(txqueue, 0, sizeof(*txqueue));
 	common->QueueDesc = queuePhys;
 	common->QueueAvail = (queuePhys) + OFFSETOF(struct VirtioQueue, available);
 	common->QueueUsed = (queuePhys) + OFFSETOF(struct VirtioQueue, used);
@@ -208,7 +248,109 @@ void AuVirtioNetTxinitialize(struct VirtioCommonCfg* common) {
 	common->QueueEnable = 1;
 	isb_flush();
 	dsb_ish();
+
+	uint64_t txbuff = (uint64_t)AuPmmngrAllocPages(4, 1, 0, AURORA_PAGE_DMA);
+	if (!txbuff) {
+		UARTDebugOut("[aurora]: unable to allocate virtio TX buffer\r\n");
+		return;
+	}
+	for (int i = 0; i < TX_BUFFER_COUNT; i++) {
+		txqueue->buffers[i].Addr = txbuff + (i * 2048);
+		txqueue->buffers[i].Length = TX_BUFFER_SIZE;
+		txqueue->buffers[i].Flags = 0;
+		txqueue->buffers[i].Next = 0;
+		txqueue->available.ring[i] = i;
+	}
+	txqueue->available.index = 0;
+	isb_flush();
+	dsb_ish();
 	UARTDebugOut("[aurora]: virtio tx queue initialized \r\n");
+}
+
+/**
+ * @brief AuVirtioTransmit -- send one Ethernet frame on virtio-net
+ * @param packet -- frame bytes
+ * @param len -- length in bytes
+ */
+static void AuVirtioTransmit(void* packet, uint16_t len) {
+	uint16_t idx;
+	uint8_t* buff;
+	virtio_net_hdr_t* hdr;
+	uint16_t total;
+	if (!txqueue || !_cfg)
+		return;
+	idx = tx_index % TX_BUFFER_COUNT;
+	buff = (uint8_t*)P2V(txqueue->buffers[idx].Addr);
+	memset(buff, 0, TX_BUFFER_SIZE);
+	hdr = (virtio_net_hdr_t*)buff;
+	hdr->gso_type = VIRTIO_NET_HDR_GSO_NONE;
+	if (len + sizeof(virtio_net_hdr_t) > TX_BUFFER_SIZE)
+		len = TX_BUFFER_SIZE - sizeof(virtio_net_hdr_t);
+	memcpy(buff + sizeof(virtio_net_hdr_t), packet, len);
+	total = (uint16_t)(len + sizeof(virtio_net_hdr_t));
+	txqueue->buffers[idx].Length = total;
+	txqueue->buffers[idx].Flags = 0;
+	txqueue->buffers[idx].Next = 0;
+	txqueue->available.ring[txqueue->available.index % TX_BUFFER_COUNT] = idx;
+	txqueue->available.index++;
+	dsb_ish();
+	isb_flush();
+	AuVirtioNetNotifyQueue(_cfg, 1);
+	tx_index++;
+}
+
+/**
+ * @brief AuVirtioWrite -- VFS write callback for the NIC
+ * @param node -- unused
+ * @param file -- unused
+ * @param buffer -- frame to send
+ * @param len -- length in bytes
+ */
+static size_t AuVirtioWrite(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t len) {
+	(void)node;
+	(void)file;
+	AuVirtioTransmit(buffer, (uint16_t)len);
+	return len;
+}
+
+/**
+ * @brief AuVirtioNetIOCtl -- NIC ioctl (MAC, IPv4, gateway, mask, link)
+ * @param file -- unused
+ * @param code -- AUNET_* request
+ * @param arg -- user buffer
+ */
+static int AuVirtioNetIOCtl(AuVFSNode* file, int code, void* arg) {
+	(void)file;
+	if (!ndev || !arg)
+		return 1;
+	switch (code) {
+	case AUNET_GET_HARDWARE_ADDRESS:
+		memcpy(arg, ndev->mac, 6);
+		return 0;
+	case AUNET_GET_IPV4_ADDRESS:
+		memcpy(arg, &ndev->ipv4addr, sizeof(ndev->ipv4addr));
+		return 0;
+	case AUNET_SET_IPV4_ADDRESS:
+		memcpy(&ndev->ipv4addr, arg, sizeof(ndev->ipv4addr));
+		return 0;
+	case AUNET_GET_GATEWAY_ADDRESS:
+		memcpy(arg, &ndev->ipv4gateway, sizeof(ndev->ipv4gateway));
+		return 0;
+	case AUNET_SET_GATEWAY_ADDRESS:
+		memcpy(&ndev->ipv4gateway, arg, sizeof(ndev->ipv4gateway));
+		return 0;
+	case AUNET_GET_SUBNET_MASK:
+		memcpy(arg, &ndev->ipv4subnet, sizeof(ndev->ipv4subnet));
+		return 0;
+	case AUNET_SET_SUBNET_MASK:
+		memcpy(&ndev->ipv4subnet, arg, sizeof(ndev->ipv4subnet));
+		return 0;
+	case AUNET_GET_LINK_STATUS:
+		memcpy(arg, &ndev->linkStatus, sizeof(ndev->linkStatus));
+		return 0;
+	default:
+		return 1;
+	}
 }
 
 /**
@@ -222,6 +364,8 @@ void AuVirtioNetInitialize(uint64_t device) {
 	int dev = 0;
 	if (device == 0xFFFFFFFF)
 		return;
+	rx_index = 0;
+	tx_index = 0;
 
 	uint16_t command = AuPCIERead(device, PCI_COMMAND, bus, dev, func);
 	command |= 4;
@@ -259,6 +403,7 @@ void AuVirtioNetInitialize(uint64_t device) {
 	}
 
 	struct VirtioCommonCfg* common = (struct VirtioCommonCfg*)finalAddr;
+	_cfg = common;
 	AuVirtioNetReset(common);
 
 	struct VirtioNetCfg* netcfg = (struct VirtioNetCfg*)(finalAddr + devcfg_offset);
@@ -296,12 +441,42 @@ void AuVirtioNetInitialize(uint64_t device) {
 	AuVirtioNetRxinitialize(common);
 	AuVirtioNetTxinitialize(common);
 	common->DeviceStatus |= 0x08;
+	common->DeviceStatus |= 0x04;
 	isb_flush();
 	dsb_ish();
 
 	UARTDebugOut("[aurora]: virtio-net-dev initialized successfully \r\n");
 	AuTextOut("[aurora]: virtio-net-dev mac : ");
-	for (int i = 0; i < 6; i++)
+	ndev = (AuNetworkDevice*)kmalloc(sizeof(AuNetworkDevice));
+	memset(ndev, 0, sizeof(AuNetworkDevice));
+	ndev->type = NETDEV_TYPE_ETHERNET;
+	ndev->linkStatus = 1;
+	ndev->ipv4addr = MAKE_IP(10, 0, 2, 15);
+	ndev->ipv4gateway = MAKE_IP(10, 0, 2, 2);
+	ndev->ipv4subnet = MAKE_IP(255, 255, 255, 0);
+	ndev->dns_ipv4_1 = MAKE_IP(10, 0, 2, 3);
+	for (int i = 0; i < 6; i++) {
 		AuTextOut("%x::", netcfg->mac[i]);
+		ndev->mac[i] = netcfg->mac[i];
+	}
 	AuTextOut("\r\n");
+
+	nic = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
+	memset(nic, 0, sizeof(AuVFSNode));
+	strcpy(nic->filename, "e1000");
+	nic->flags = FS_FLAG_DEVICE;
+	nic->write = AuVirtioWrite;
+	nic->iocontrol = AuVirtioNetIOCtl;
+	nic->device = ndev;
+	AuAddNetAdapter(nic, "e1000");
+	{
+		AuVFSNode* alias = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
+		memset(alias, 0, sizeof(AuVFSNode));
+		strcpy(alias->filename, "virtio-net");
+		alias->flags = FS_FLAG_DEVICE;
+		alias->write = AuVirtioWrite;
+		alias->iocontrol = AuVirtioNetIOCtl;
+		alias->device = ndev;
+		AuAddNetAdapter(alias, "virtio-net");
+	}
 }

--- a/KernelAA64/aucon.c
+++ b/KernelAA64/aucon.c
@@ -47,13 +47,13 @@
 #include <Hal/AA64/sched.h>
 #include <process.h>
 #include <Fs/vfs.h>
+#include <Fs/tty.h>
 #include <Fs/Dev/devfs.h>
-#include <Drivers/uart.h>
+#include <Fs/Dev/devinput.h>
 #include <Drivers/uart.h>
 #include <Hal/AA64/aa64cpu.h>
 #include <Hal/AA64/aa64lowlevel.h>
 #include <Ipc/postbox.h>
-#include <Drivers/uart.h>
 
 uint8_t* font_data;
 uint32_t console_x;
@@ -104,13 +104,25 @@ void AuConsoleInitialize(PKERNEL_BOOT_INFO info, bool early) {
 int AuConsoleIoControl(AuVFSNode* file, int code, void* arg) {
 	int ret = 0;
 	AuFileIOControl* ioctl = (AuFileIOControl*)arg;
-	/*if (ioctl->syscall_magic != AURORA_SYSCALL_MAGIC)
-		return 0;*/
+	(void)file;
 
 	if (!aucon)
 		return 0;
 
 	switch (code) {
+	case TIOCGWINSZ: {
+		WinSize* sz = (WinSize*)arg;
+		if (!sz)
+			return 0;
+		sz->ws_col = (uint16_t)(aucon->width / 9);
+		sz->ws_row = (uint16_t)(aucon->height / 16);
+		sz->ws_xpixel = (uint16_t)aucon->width;
+		sz->ws_ypixel = (uint16_t)aucon->height;
+		return 0;
+	}
+	case TIOCSWINSZ:
+	case TIOSPGRP:
+		return 0;
 	case SCREEN_GETWIDTH: {
 		uint32_t width = aucon->width;
 		ioctl->uint_1 = width;
@@ -166,6 +178,119 @@ int AuConsoleIoControl(AuVFSNode* file, int code, void* arg) {
 	}
 	}
 	return ret;
+}
+
+static int _con_shift;
+static int _con_esc;
+
+static const char _con_map[58] = {
+	0,	 0,	  '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', '\b',
+	'\t', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '[', ']', '\n', 0,
+	'a',  's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';', '\'', '`', 0,	 '\\',
+	'z',  'x', 'c', 'v', 'b', 'n', 'm', ',', '.', '/', 0,	0,	 0,	 ' '
+};
+
+static const char _con_map_s[58] = {
+	0,	 0,	  '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '\b',
+	'\t', 'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', '{', '}', '\n', 0,
+	'A',  'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L', ':', '"', '~', 0,	 '|',
+	'Z',  'X', 'C', 'V', 'B', 'N', 'M', '<', '>', '?', 0,	0,	 0,	 ' '
+};
+
+/**
+ * @brief AuConsoleMapKey -- map a virtio/XT scancode to ASCII
+ * @param code -- scancode from /dev/kybrd
+ */
+static char AuConsoleMapKey(uint32_t code) {
+	uint8_t sc = (uint8_t)(code & 0xFF);
+	if (sc == 0x2a || sc == 0x36) {
+		_con_shift = 1;
+		return 0;
+	}
+	if (sc == 0xaa || sc == 0xb6) {
+		_con_shift = 0;
+		return 0;
+	}
+	if (sc & 0x80)
+		return 0;
+	if (sc >= sizeof(_con_map))
+		return 0;
+	return _con_shift ? _con_map_s[sc] : _con_map[sc];
+}
+
+/**
+ * @brief AuConsoleRead -- read ASCII from the virtio keyboard
+ * @param node -- unused
+ * @param file -- unused
+ * @param buffer -- destination
+ * @param length -- max bytes
+ */
+static size_t AuConsoleRead(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t length) {
+	uint8_t* out;
+	uint32_t n;
+	(void)node;
+	(void)file;
+	if (!buffer || !length)
+		return 0;
+	out = (uint8_t*)buffer;
+	n = 0;
+	while (n < length) {
+		AuInputMessage msg;
+		char c;
+		memset(&msg, 0, sizeof(msg));
+		AuDevReadKybrd(&msg);
+		c = 0;
+		if (msg.type == AU_INPUT_KEYBOARD)
+			c = AuConsoleMapKey(msg.code);
+		if (c) {
+			out[n++] = (uint8_t)c;
+			if (c == '\n')
+				break;
+		} else {
+			if (n)
+				break;
+			AA64Thread* thr = AuGetCurrentThread();
+			if (thr) {
+				AuSleepThread(thr, 10);
+				AuScheduleNext();
+			}
+		}
+	}
+	return n;
+}
+
+/**
+ * @brief AuConsoleWrite -- draw bytes on the GOP/ramfb console
+ * @param node -- unused
+ * @param file -- unused
+ * @param buffer -- source
+ * @param length -- byte count
+ */
+static size_t AuConsoleWrite(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t length) {
+	uint8_t* in;
+	uint32_t i;
+	(void)node;
+	(void)file;
+	if (!buffer)
+		return 0;
+	in = (uint8_t*)buffer;
+	for (i = 0; i < length; i++) {
+		char c = (char)in[i];
+		char tmp[2];
+		if (_con_esc) {
+			if (c == 0x07 || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z'))
+				_con_esc = 0;
+			continue;
+		}
+		if (c == 0x1b) {
+			_con_esc = 1;
+			continue;
+		}
+		tmp[0] = c;
+		tmp[1] = 0;
+		AuPutS(tmp);
+	}
+	return length;
 }
 
 /**
@@ -234,6 +359,15 @@ void AuConsolePostInitialise(PKERNEL_BOOT_INFO info) {
 	file->device = fsys;
 	file->read = 0;
 	file->write = 0;
+	file->iocontrol = AuConsoleIoControl;
+	AuDevFSAddFile(fsys, "/", file);
+
+	file = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
+	memset(file, 0, sizeof(AuVFSNode));
+	strcpy(file->filename, "console");
+	file->flags = FS_FLAG_DEVICE;
+	file->read = AuConsoleRead;
+	file->write = AuConsoleWrite;
 	file->iocontrol = AuConsoleIoControl;
 	AuDevFSAddFile(fsys, "/", file);
 }

--- a/Process/Init/_init.cpp
+++ b/Process/Init/_init.cpp
@@ -234,14 +234,14 @@ extern "C" void main(int argc, char* argv[]) {
 #endif
 	}
 
-#ifndef __XENEVA_BLEED__
+#if !defined(__XENEVA_BLEED__) && !defined(__XENEVA_TERM__)
 	SplashScreenShow();
 #endif
 	_sound = -1;
 	init_basic_gid_to_dev();
 
 	/** play the startup sound, for better experience */
-#ifndef __XENEVA_BLEED__
+#if !defined(__XENEVA_BLEED__) && !defined(__XENEVA_TERM__)
 	_play_startup_sound();
 #endif
 
@@ -267,6 +267,32 @@ extern "C" void main(int argc, char* argv[]) {
 	int proc = 0;
 
 #ifdef ARCH_ARM64
+#ifdef __XENEVA_TERM__
+	_KePrint("[init]: tty, skipping compositor \r\n");
+	proc = _KeCreateProcess(0, "netmngr");
+	int ret_nm = _KeProcessLoadExec(proc, "/netmngr.exe", 0, NULL);
+	if (ret_nm != -1) {
+		_KeSetUID(proc, UAC_DEAMONS);
+		_KeSetGID(proc, UAC_DEAMONS);
+		_KeCredAddSGroup(proc, ggid_misc_world);
+		_KeCredAddSGroup(proc, GROUP_NETWORK);
+		_KeProcessSleep(500);
+	}
+	int con = _KeOpenFile("/dev/console", FILE_OPEN_READ_ONLY);
+	if (con == -1)
+		_KePrint("[init]: failed to open /dev/console \r\n");
+	proc = _KeCreateProcess(0, "xesh");
+	_KeSetUID(proc, UAC_NORMAL_USER);
+	_KeSetGID(proc, UAC_NORMAL_USER);
+	_KeCredAddSGroup(proc, ggid_misc_world);
+	_KeCredAddSGroup(proc, GROUP_NETWORK);
+	if (con != -1) {
+		_KeSetFileToProcess(con, XENEVA_STDIN, proc);
+		_KeSetFileToProcess(con, XENEVA_STDOUT, proc);
+		_KeSetFileToProcess(con, XENEVA_STDERR, proc);
+	}
+	_KeProcessLoadExec(proc, "/xesh.exe", 0, NULL);
+#else
 #ifndef __XENEVA_BLEED__
 	proc = _KeCreateProcess(0, "netmngr");
 	int ret_nm = _KeProcessLoadExec(proc, "/netmngr.exe", 0, NULL);
@@ -307,6 +333,7 @@ extern "C" void main(int argc, char* argv[]) {
 	_KeCredAddSGroup(proc, GROUP_AUDIO);
 	_KeCredAddSGroup(proc, ggid_misc_postbox);
 	_KeProcessLoadExec(proc, "/deoaud.exe", 0, NULL);
+#endif
 #endif
 
 #elif ARCH_X64

--- a/Process/ping/Makefile
+++ b/Process/ping/Makefile
@@ -1,0 +1,45 @@
+# LLVM ping.exe, statically linked with Process/Init/crt0arm64.s.
+
+TOOLCHAIN ?= gcc
+TARGET = ping.exe
+INCLUDES = -I../../Libs/XEClib/includes -I../../Libs/XEClib/includes/c++ -I../../BaseHdr
+OBJDIR = obj
+CPP_OBJS = $(OBJDIR)/main.o
+S_OBJS = $(OBJDIR)/crt0_arm64.o
+OBJS = $(CPP_OBJS) $(S_OBJS)
+
+ifeq ($(TOOLCHAIN), llvm)
+    CXX = clang++
+    CC  = clang
+    LD  = clang++
+    LLVM_TARGET = -target aarch64-unknown-windows
+    CXXFLAGS = -Wall -Wextra -ffreestanding -fno-stack-protector -fno-stack-check -fno-strict-aliasing \
+               -O2 -fno-exceptions -fno-rtti $(LLVM_TARGET) \
+               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS \
+               -Wno-error=incompatible-pointer-types -Wno-error=int-conversion \
+               -Wno-implicit-function-declaration -Wno-c++11-narrowing \
+               $(INCLUDES)
+    LDFLAGS = $(LLVM_TARGET) -fuse-ld=lld -nostdlib -Wl,-entry:_aumain -Wl,-base:0x600000000 -Wl,-subsystem:native
+endif
+
+.PHONY: all clean llvm
+llvm:
+	@$(MAKE) TOOLCHAIN=llvm all
+
+all: $(TARGET)
+
+ifeq ($(TOOLCHAIN), llvm)
+$(TARGET): $(OBJS)
+	$(LD) $(LDFLAGS) $(OBJS) ../../Libs/XEClib/libXEClib.a -o $@
+endif
+
+$(OBJDIR)/main.o: main.cpp
+	@mkdir -p $(OBJDIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(OBJDIR)/crt0_arm64.o: ../../Process/Init/crt0arm64.s
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CXXFLAGS) -Wno-unused-command-line-argument -c $< -o $@
+
+clean:
+	rm -rf $(OBJDIR) $(TARGET)

--- a/Process/ping/main.cpp
+++ b/Process/ping/main.cpp
@@ -136,6 +136,7 @@ int main(int argc, char* argv[]) {
 			break;
 
 		ping->sequenceNum = htons(pings_sent + 1);
+		ping->checksum = 0;
 		ping->checksum = htons(ICMPCalculateChecksum((char*)ping, BYTES_TO_SEND));
 
 		if (sendto(sock, (void*)ping, BYTES_TO_SEND, 0, (sockaddr*)&dest, sizeof(sockaddr_in)) <
@@ -147,6 +148,7 @@ int main(int argc, char* argv[]) {
 		pings_sent++;
 
 		src_sz = sizeof(sockaddr_in);
+		timeout = 1000;
 		while (timeout--) {
 			len = recvfrom(sock, data, 4096, 0, (sockaddr*)&src, &src_sz);
 
@@ -160,9 +162,8 @@ int main(int argc, char* argv[]) {
 					break;
 				}
 			}
+			_KeProcessSleep(10);
 		}
-		timeout = 1000;
-		//_KeProcessSleep(100);
 		sleep(1);
 	}
 

--- a/Scripts/Linux/build_and_run_qemu.sh
+++ b/Scripts/Linux/build_and_run_qemu.sh
@@ -24,6 +24,8 @@ set -e
 #                           instead of opening a GTK window. Ordinary builds
 #                           stop at the interactive resolution menu; bleed
 #                           selects 640x480 automatically and boots through it.
+#   --term                  Open the QEMU window with a framebuffer TTY (no
+#                           compositor). Init starts xesh.exe on /dev/console.
 #   -h, --help              Show this help and exit.
 #
 # Known gap: x86_64 (Boot/Kernel) has no QEMU boot path here yet.
@@ -43,11 +45,12 @@ INSTALL_DEPS=0
 HEADLESS=0
 BLEED=0
 DIRECT_SCANOUT=0
+TERM=0
 INITRD_SIZE_MB=""
 
 print_help(){
     printf "${STY_CYAN}"
-    sed -n '3,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '3,29p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     printf "${STY_RST}\n"
 }
 
@@ -62,6 +65,7 @@ for arg in "$@"; do
         --force-legacy-build) FORCE_LEGACY_BUILD=1 ;;
         --install-deps) INSTALL_DEPS=1 ;;
         --headless) HEADLESS=1 ;;
+        --term) TERM=1 ;;
         --initrd-size-mb=*) INITRD_SIZE_MB="${arg#--initrd-size-mb=}" ;;
         -h|--help) print_help; exit 0 ;;
         *)
@@ -211,6 +215,17 @@ if [ "$SKIP_BUILD" -eq 0 ]; then
         mkdir -p "$(dirname "$USERSPACE_PROFILE_STAMP")"
         printf '%s\n' "$requested_userspace_profile" > "$USERSPACE_PROFILE_STAMP"
     fi
+    if [ "$TERM" -eq 1 ]; then
+        echo "[+] Rebuilding init.exe and ping.exe for framebuffer TTY..."
+        term_flags="-D__XENEVA_TERM__"
+        if [ "$BLEED" -eq 1 ]; then
+            term_flags="-D__XENEVA_BLEED__ -D__XENEVA_TERM__"
+        fi
+        ( cd "$REPO_ROOT/Process/Init" && make clean && make BLEED_FLAGS="$term_flags" llvm )
+        ( cd "$REPO_ROOT/Process/ping" && make clean && make llvm )
+        cp -f "$REPO_ROOT/Process/Init/init.exe" "$REPO_ROOT/Resources/resources/"
+        cp -f "$REPO_ROOT/Process/ping/ping.exe" "$REPO_ROOT/Resources/resources/"
+    fi
 else
     echo "[+] --skip-build passed, reusing existing build artifacts."
 fi
@@ -286,6 +301,8 @@ QEMU_ARGS=(
     -m "$qemu_memory"
     -bios "$QEMU_FIRMWARE"
     -drive file=fat.img,format=raw,if=virtio
+    -netdev user,id=net0
+    -device virtio-net-pci,netdev=net0
     -device ramfb
     -device virtio-keyboard-pci
     -device virtio-tablet-pci
@@ -296,7 +313,6 @@ QEMU_ARGS=(
 
 if [ "$HEADLESS" -eq 1 ]; then
     QEMU_ARGS+=(-display none -no-reboot)
-
     # Ordinary builds still block at the interactive resolution menu. Bleed
     # selects its low-memory mode in the bootloader and can therefore complete
     # an automated headless boot; the timeout bounds both cases for CI.


### PR DESCRIPTION
## Summary
Make QEMU virt networking and a no-compositor serial-style TTY work on AArch64 so `ping www.getxeneva.com` runs from xesh.

## Changes
### virtio-net (`virt.c`, `virtionet.c`)
- **Before:** NIC initialization was commented out; TX used 2 descriptors with 1 index, causing even frames to be corrupted.
- **What:** Probe and initialize virtio-net, use one TX descriptor per frame, and register the device as `e1000`.
- **Why:** Existing userspace binds to `e1000`; without proper NIC initialization, ICMP frames never left the NIC.

### ping (`main.cpp`, `Makefile`)
- **Before:** Checksum was reused, `recvfrom` did not wait for replies, and dynamic PE linking required a sleep from `XEClib.dll`.
- **What:** Zero the checksum before recalculation, add a sleep in the receive loop, and use static LLVM linking.
- **Why:** Fixes intermittent ping replies (including 6/5 packet loss) and avoids `xeldr`/`printf` crashes.

### console + Init (`aucon.c`, `_init.cpp`)
- **Before:** No `/dev/console` was available; Init always started the compositor.
- **What:** Add a framebuffer TTY and support `--term` to skip Deodhai and start xesh directly on the console.
- **Why:** Provides a windowless TTY path without requiring Deodhai.

### QEMU (`build_and_run_qemu.sh`)
- **Before:** No `--term` option and no virtio-net-pci device configuration.
- **What:** Add the `--term` flag and configure the QEMU network device through `QEMU_ARGS`.
- **Why:** Provides a single place to configure the QEMU NIC and enables booting directly into the TTY path.

## Compatibility
- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [x] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.

## Related
N/A