### PR TITLE
Kernel r&d

### DIFF
--- a/BaseHdr/Net/ipv4.h
+++ b/BaseHdr/Net/ipv4.h
@@ -30,7 +30,7 @@
 #ifndef __IPV4_H__
 #define __IPV4_H__
 
-#ifdef ARCH_X64
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
 #pragma pack(push,1)
 #endif
 typedef struct _ipv4head_ {
@@ -46,7 +46,7 @@ typedef struct _ipv4head_ {
 	unsigned destAddress;
 	uint8_t payload[];
 }IPv4Header;
-#ifdef ARCH_X64
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
 #pragma pack(pop)
 #endif
 

--- a/BaseHdr/Net/socket.h
+++ b/BaseHdr/Net/socket.h
@@ -92,8 +92,10 @@ typedef struct _msghdr_ {
 }msghdr;
 
 
-#define SOCK_STATE_WAITING_FOR_CONNECTION 1
 #define SOCK_STATE_CONNECTION_RST 0
+#define SOCK_STATE_WAITING_FOR_CONNECTION 1
+#define SOCK_STATE_CONNECTED 2
+#define SOCK_STATE_CLOSED 3
 
 #ifdef ARCH_X64
 #pragma pack(push,1)
@@ -110,6 +112,9 @@ typedef struct _socket_ {
 	void(*close)(struct _socket_* sock);
 	int(*connect)(struct _socket_* sock, sockaddr* addr, socklen_t addrlen);
 	int(*bind)(struct _socket_* sock, sockaddr* addr, socklen_t addrlen);
+	int(*listen)(struct _socket_* sock, int backlog);
+	int(*accept)(struct _socket_* sock, sockaddr* addr, socklen_t* addrlen);
+	void* proto;
 }AuSocket;
 #ifdef ARCH_X64
 #pragma pack(pop)

--- a/BaseHdr/Net/tcp.h
+++ b/BaseHdr/Net/tcp.h
@@ -47,8 +47,22 @@
 #define TCP_DATA_OFFSET_5 (0x5 << 12)
 
 #define TCP_DEFAULT_WIN_SZ 65535
+#define TCP_MSS 1460
+#define TCP_RX_BUF_SZ 16384
 
-#ifdef ARCH_X64
+#define TCP_STATE_CLOSED       0
+#define TCP_STATE_LISTEN       1
+#define TCP_STATE_SYN_SENT     2
+#define TCP_STATE_SYN_RECEIVED 3
+#define TCP_STATE_ESTABLISHED  4
+#define TCP_STATE_FIN_WAIT_1   5
+#define TCP_STATE_FIN_WAIT_2   6
+#define TCP_STATE_CLOSE_WAIT   7
+#define TCP_STATE_CLOSING      8
+#define TCP_STATE_LAST_ACK     9
+#define TCP_STATE_TIME_WAIT    10
+
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
 #pragma pack(push,1)
 #endif
 typedef struct _tcphead_ {
@@ -61,9 +75,30 @@ typedef struct _tcphead_ {
 	unsigned short checksum;
 	unsigned short urgentPointer;
 }TCPHeader;
-#ifdef ARCH_X64
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
 #pragma pack(pop)
 #endif
+
+typedef struct _tcp_pcb_ {
+	uint8_t state;
+	uint8_t fin_recvd;
+	uint32_t iss;
+	uint32_t irs;
+	uint32_t snd_una;
+	uint32_t snd_nxt;
+	uint32_t rcv_nxt;
+	uint32_t remote_ip;
+	uint16_t remote_port;
+	uint16_t snd_wnd;
+	uint16_t rcv_wnd;
+	uint16_t mss;
+	int backlog;
+	AuVFSNode* nic;
+	struct _socket_* parent;
+	void* rxbuf;
+	uint8_t* rxmem;
+	list_t* acceptq;
+} TCPControlBlock;
 
 /*
 * CreateTCPSocket -- creates a new TCP Socket
@@ -84,6 +119,11 @@ extern list_t* TCPGetSocketList();
  * @param payloadLen -- length of the payload
 */
 extern int AuTCPAcknowledge(AuVFSNode* nic, AuSocket* sock, IPv4Header* ippack, size_t payloadLen);
+
+/*
+ * TCPHandlePacket -- dispatch an incoming TCP segment
+ */
+extern void TCPHandlePacket(IPv4Header* pack, AuVFSNode* nic);
 
 /*
  * TCPProtocolInstall -- initialize the TCP protocol

--- a/KernelAA64/Drivers/virtiokbd.c
+++ b/KernelAA64/Drivers/virtiokbd.c
@@ -64,52 +64,62 @@ static const uint8_t ext_key_map[256] = {
  * @brief Virtio-keyboard interrupt handler
  */
 void AuVirtioKbdHandler(int spinum) {
-	uint16_t them = queue->used.index;
-	for (; index < them; index++) {
-		dc_ivac((uint64_t)&input[index % queueSize]);
+	uint16_t them;
+	(void)spinum;
+	if (!queue || !input || queueSize <= 0)
+		return;
+	them = queue->used.index;
+	for (; index != them; index++) {
+		uint16_t slot = index % (uint16_t)queueSize;
+		uint16_t buf_id;
+		uint16_t avail;
+		struct VirtioInputEvent evt;
+
+		dc_ivac((uint64_t)&queue->used.ring[slot]);
+		dc_ivac((uint64_t)&input[slot]);
 		dsb_sy_barrier();
-		struct VirtioInputEvent evt = input[index % queueSize];
-		while (evt.type == 0xFF) {
-			evt = input[index % queueSize];
-			UARTDebugOut("VirtioInput: bad packet : %d (them=%d)\n", index, them);
-		}
-		input[index % queueSize].type = 0xFF;
+		buf_id = (uint16_t)(queue->used.ring[slot].index % (uint32_t)queueSize);
+		evt = input[buf_id];
+		input[buf_id].type = 0xFF;
 		isb_flush();
 		dsb_sy_barrier();
 		if (evt.type == 1) {
-			if (evt.code < 0x49) {
-				uint8_t scancode = evt.code;
-				// Key Release: value |= 0x80;
-				// Key Release: value = code
-				if (evt.value == 0) {
+			/* Linux KEY_ENTER=28, KEY_KPENTER=96 */
+			if (evt.code == 28 || evt.code == 96) {
+				uint8_t scancode = 0x1c;
+				if (evt.value == 0)
 					scancode |= 0x80;
-				}
-				/* write to xeneva key input msg box */
-				AuInputMessage msg;
-				memset(&msg, 0, sizeof(AuInputMessage));
-				msg.type = AU_INPUT_KEYBOARD;
-				msg.code = scancode & 0xFF;
-				AuDevWriteKybrd(&msg);
-			} else if (ext_key_map[evt.code]) {
-				uint8_t make_code = ext_key_map[evt.code] & 0xFF;
-
-				if (evt.value == 0) {
-					make_code |= 0x80;
-				}
-				uint32_t scancode = (0xE0 << 8) | make_code;
-				// 0xE0 (extended code)  upper 16 bits | key code middle 8 bits | value: 0x80 for release, 0 press
-				/* write to xeneva key input msg box */
 				AuInputMessage msg;
 				memset(&msg, 0, sizeof(AuInputMessage));
 				msg.type = AU_INPUT_KEYBOARD;
 				msg.code = scancode;
 				AuDevWriteKybrd(&msg);
-			} else {
-				UARTDebugOut("virtio-kybrd: unmapped key code : %d \n", evt.code);
+			} else if (evt.code < 0x49) {
+				uint8_t scancode = (uint8_t)evt.code;
+				if (evt.value == 0)
+					scancode |= 0x80;
+				AuInputMessage msg;
+				memset(&msg, 0, sizeof(AuInputMessage));
+				msg.type = AU_INPUT_KEYBOARD;
+				msg.code = scancode;
+				AuDevWriteKybrd(&msg);
+			} else if (ext_key_map[evt.code]) {
+				uint8_t make_code = ext_key_map[evt.code];
+				if (evt.value == 0)
+					make_code |= 0x80;
+				AuInputMessage msg;
+				memset(&msg, 0, sizeof(AuInputMessage));
+				msg.type = AU_INPUT_KEYBOARD;
+				msg.code = (0xE0u << 8) | make_code;
+				AuDevWriteKybrd(&msg);
 			}
 		}
+		avail = queue->available.index;
+		queue->available.ring[avail % (uint16_t)queueSize] = buf_id;
+		dsb_ish();
+		queue->available.index = avail + 1;
 		isb_flush();
-		queue->available.index++;
+		dsb_sy_barrier();
 	}
 }
 
@@ -197,6 +207,13 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	dsb_ish();
 
 	int queueSz = common->QueueSize;
+	if (queueSz > 64)
+		queueSz = 64;
+	if (queueSz < 1)
+		queueSz = 1;
+	common->QueueSize = (uint16_t)queueSz;
+	isb_flush();
+	dsb_ish();
 	queueSize = queueSz;
 	UARTDebugOut("virtio: queue sz : %d \n", queueSz);
 
@@ -236,8 +253,7 @@ void AuVirtioKbdInitialize(uint64_t device) {
 	isb_flush();
 	dsb_ish();
 
-	uint16_t index = 0;
-	queue->available.index = queueSz - 1;
+	queue->available.index = (uint16_t)queueSz;
 	isb_flush();
 	dsb_ish();
 }

--- a/KernelAA64/Fs/Dev/devinput.c
+++ b/KernelAA64/Fs/Dev/devinput.c
@@ -39,6 +39,10 @@
 AuVFSNode* mice_;
 AuVFSNode* kybrd_;
 
+static AuInputMessage kbd_q[NUM_KEYBOARD_PACKETS];
+static uint32_t kbd_r;
+static uint32_t kbd_w;
+
 /*
  * AuDevReadMice -- reads packets from pipe
  * to buffer
@@ -67,10 +71,13 @@ void AuDevWriteMice(AuInputMessage* outmsg) {
 * @para, inputmsg -- Pointer to the buffer
 */
 void AuDevReadKybrd(AuInputMessage* inputmsg) {
-	if (!kybrd_)
+	if (!inputmsg)
 		return;
-	memcpy(inputmsg, kybrd_->device, sizeof(AuInputMessage));
-	memset(kybrd_->device, 0, sizeof(AuInputMessage));
+	memset(inputmsg, 0, sizeof(AuInputMessage));
+	if (kbd_r == kbd_w)
+		return;
+	memcpy(inputmsg, &kbd_q[kbd_r], sizeof(AuInputMessage));
+	kbd_r = (kbd_r + 1) % NUM_KEYBOARD_PACKETS;
 }
 
 /*
@@ -78,9 +85,14 @@ void AuDevReadKybrd(AuInputMessage* inputmsg) {
 * @param outmsg -- packet to write
 */
 void AuDevWriteKybrd(AuInputMessage* outmsg) {
-	if (!kybrd_)
+	uint32_t next;
+	if (!outmsg)
 		return;
-	memcpy(kybrd_->device, outmsg, sizeof(AuInputMessage));
+	next = (kbd_w + 1) % NUM_KEYBOARD_PACKETS;
+	if (next == kbd_r)
+		kbd_r = (kbd_r + 1) % NUM_KEYBOARD_PACKETS;
+	memcpy(&kbd_q[kbd_w], outmsg, sizeof(AuInputMessage));
+	kbd_w = next;
 }
 
 /*
@@ -130,8 +142,7 @@ size_t AuDevInputKybrdWrite(AuVFSNode* fs, AuVFSNode* file, uint64_t* buffer, ui
 		return 0;
 	if (!buffer)
 		return 0;
-	void* key_buf = file->device;
-	memcpy(key_buf, buffer, sizeof(AuInputMessage));
+	AuDevWriteKybrd((AuInputMessage*)buffer);
 	return (sizeof(AuInputMessage));
 }
 
@@ -147,9 +158,7 @@ size_t AuDevInputKybrdRead(AuVFSNode* fs, AuVFSNode* file, uint64_t* buffer, uin
 		return 0;
 	if (!buffer)
 		return 0;
-	void* key_buf = file->device;
-	memcpy(buffer, key_buf, sizeof(AuInputMessage));
-	memset(key_buf, 0, sizeof(AuInputMessage));
+	AuDevReadKybrd((AuInputMessage*)buffer);
 	return (sizeof(AuInputMessage));
 }
 

--- a/KernelAA64/Net/aunet.c
+++ b/KernelAA64/Net/aunet.c
@@ -59,7 +59,7 @@ void AuInitialiseNet() {
 	ARPProtocolInitialise();
 	UDPProtocolInstall();
 	ICMPInitialise();
-	//TCPProtocolInstall();
+	TCPProtocolInstall();
 	AuTextOut("[aurora]: net system initialised \r\n");
 }
 

--- a/KernelAA64/Net/ipv4.c
+++ b/KernelAA64/Net/ipv4.c
@@ -94,12 +94,7 @@ void IPv4HandlePacket(void* data, AuVFSNode* nic) {
 		break;
 	}
 	case IPV4_PROTOCOL_TCP: {
-		UARTDebugOut("[ipv4] : received TCP packet \r\n");
-		TCPHeader* tcp = (TCPHeader*)&pack->payload;
-		uint16_t destPort = ntohs(tcp->destPort);
-		uint16_t srcPort = ntohs(tcp->srcPort);
-		UARTDebugOut("destination port : %d \n", destPort);
-		UARTDebugOut("source port : %d \n", srcPort);
+		TCPHandlePacket(pack, nic);
 		break;
 	}
 	}
@@ -122,10 +117,13 @@ int CreateIPv4Socket(int type, int protocol) {
 			UARTDebugOut("[aurora]: ipv4 icmp protocol created \r\n");
 			return CreateICMPSocket();
 		}
-	case SOCK_STREAM: {
-		UARTDebugOut("[aurora]: tcp protocol created \r\n");
-		return 0; // CreateTCPSocket();
-	}
+		return -1;
+	case SOCK_STREAM:
+		if (protocol == 0 || protocol == IPPROTOCOL_TCP) {
+			UARTDebugOut("[aurora]: tcp protocol created \r\n");
+			return CreateTCPSocket();
+		}
+		return -1;
 	default:
 		return -1;
 	}

--- a/KernelAA64/Net/netserv.c
+++ b/KernelAA64/Net/netserv.c
@@ -118,9 +118,51 @@ int NetBind(int sockfd, sockaddr* addr, socklen_t addrlen) {
 }
 
 int NetAccept(int sockfd, sockaddr* addr, socklen_t* addrlen) {
-	return 0;
+	AA64Thread* thr = AuGetCurrentThread();
+	AuProcess* proc;
+	AuVFSNode* node;
+	AuSocket* sock;
+
+	if (!thr)
+		return -1;
+	proc = AuProcessFindThread(thr);
+	if (!proc) {
+		proc = AuProcessFindSubThread(thr);
+		if (!proc)
+			return -1;
+	}
+	node = proc->fds[sockfd];
+	if (!node)
+		return -1;
+	sock = (AuSocket*)node->device;
+	if (!sock)
+		return -1;
+	if (sock->accept)
+		return sock->accept(sock, addr, addrlen);
+	return -1;
 }
 
 int NetListen(int sockfd, int backlog) {
-	return 0;
+	AA64Thread* thr = AuGetCurrentThread();
+	AuProcess* proc;
+	AuVFSNode* node;
+	AuSocket* sock;
+
+	if (!thr)
+		return -1;
+	proc = AuProcessFindThread(thr);
+	if (!proc) {
+		proc = AuProcessFindSubThread(thr);
+		if (!proc)
+			return -1;
+	}
+	node = proc->fds[sockfd];
+	if (!node)
+		return -1;
+	sock = (AuSocket*)node->device;
+	if (!sock)
+		return -1;
+	if (sock->listen)
+		return sock->listen(sock, backlog);
+	return -1;
 }

--- a/KernelAA64/Net/tcp.c
+++ b/KernelAA64/Net/tcp.c
@@ -1,7 +1,7 @@
 /**
 * BSD 2-Clause License
 *
-* Copyright (c) 2022-2024, Manas Kamal Choudhury
+* Copyright (c) 2022-2026, Manas Kamal Choudhury
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -35,14 +35,21 @@
 #include <stack.h>
 #include <Net/tcp.h>
 #include <Net/ipv4.h>
-#include <stdio.h>
-#include <aucon.h>
 #include <Hal/AA64/aa64lowlevel.h>
+#include <Hal/AA64/aa64cpu.h>
 #include <Hal/AA64/sched.h>
 #include <Drivers/uart.h>
+#include <circbuf.h>
+#include <_null.h>
+
+extern int rand();
 
 list_t* tcpSocketList;
+static int _tcp_port_ = 49152;
 
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
+#pragma pack(push, 1)
+#endif
 typedef struct _tcpcheckheader_ {
 	uint32_t source;
 	uint32_t destination;
@@ -51,276 +58,909 @@ typedef struct _tcpcheckheader_ {
 	uint16_t tcpLen;
 	uint8_t tcpHeader[];
 } TCPCheckHeader;
+#if defined(ARCH_X64) || defined(ARCH_ARM64)
+#pragma pack(pop)
+#endif
 
-/**  Implementation needed **/
-
-/*
- * CalculateTCPChecksum -- calculate tcp checksum
- * @param p -- Pointer to TCP Checksum header
- * @param h -- Pointer to TCP header
- * @param d -- Payload
- * @param payloadsz -- size of the payload
- */
-uint16_t CalculateTCPChecksum(TCPCheckHeader* p, TCPHeader* h, void* d, size_t payloadsz) {
+static uint16_t CalculateTCPChecksum(TCPCheckHeader* p, TCPHeader* h, void* d, size_t payloadsz) {
 	uint32_t sum = 0;
 	uint16_t* s = (uint16_t*)p;
+	int i;
 
-	for (int i = 0; i < 6; ++i) {
+	for (i = 0; i < 6; ++i) {
 		sum += ntohs(s[i]);
 		if (sum > 0xFFFF)
 			sum = (sum >> 16) + (sum & 0xFFFF);
 	}
 
 	s = (uint16_t*)h;
-	for (int i = 0; i < 10; ++i) {
+	for (i = 0; i < 10; ++i) {
 		sum += ntohs(s[i]);
 		if (sum > 0xFFFF)
 			sum = (sum >> 16) + (sum & 0xFFFF);
 	}
 
-	uint16_t dwords = payloadsz / 2;
-	s = (uint16_t*)d;
-	for (unsigned int i = 0; i < dwords; ++i) {
-		sum += ntohs(s[i]);
-		if (sum > 0xFFFF)
-			sum = (sum >> 16) + (sum & 0xFFFF);
-	}
+	if (d && payloadsz) {
+		uint16_t dwords = payloadsz / 2;
+		s = (uint16_t*)d;
+		for (unsigned int n = 0; n < dwords; ++n) {
+			sum += ntohs(s[n]);
+			if (sum > 0xFFFF)
+				sum = (sum >> 16) + (sum & 0xFFFF);
+		}
 
-	if (dwords * 2 != payloadsz) {
-		uint8_t* t = (uint8_t*)d;
-		uint8_t tmp[2];
-		tmp[0] = t[dwords * sizeof(uint16_t)];
-		tmp[1] = 0;
-
-		uint16_t* f = (uint16_t*)tmp;
-
-		sum += ntohs(f[0]);
-		if (sum > 0xFFFF)
-			sum = (sum >> 16) + (sum & 0xFFFF);
+		if (dwords * 2 != payloadsz) {
+			uint8_t* t = (uint8_t*)d;
+			uint8_t tmp[2];
+			tmp[0] = t[dwords * sizeof(uint16_t)];
+			tmp[1] = 0;
+			sum += ntohs(*(uint16_t*)tmp);
+			if (sum > 0xFFFF)
+				sum = (sum >> 16) + (sum & 0xFFFF);
+		}
 	}
 
 	return ~(sum & 0xFFFF) & 0xFFFF;
 }
-/*
- * AuTCPReceive -- TCP protocol receive interface
- * @param sock -- Pointer to socket
- * @param msghdr -- Message header containing every information
- * @param flags -- extra flags
- */
-int AuTCPReceive(AuSocket* sock, msghdr* msg, int flags) {
+
+static TCPControlBlock* TCPGetPCB(AuSocket* sock) {
+	if (!sock)
+		return NULL;
+	return (TCPControlBlock*)sock->proto;
+}
+
+static uint16_t TCPFlagsOf(TCPHeader* tcp) {
+	return ntohs(tcp->dataOffsetFlags) & 0x01FF;
+}
+
+static int TCPHdrBytes(TCPHeader* tcp) {
+	return ((ntohs(tcp->dataOffsetFlags) >> 12) & 0xF) * 4;
+}
+
+static uint16_t TCPWindowOf(AuSocket* sock) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	size_t used;
+
+	if (!pcb || !pcb->rxbuf)
+		return TCP_DEFAULT_WIN_SZ;
+	used = AuCircBufSize((CircBuffer*)pcb->rxbuf);
+	if (used >= TCP_RX_BUF_SZ)
+		return 0;
+	return (uint16_t)(TCP_RX_BUF_SZ - used);
+}
+
+static int TCPPortInUse(uint16_t port) {
+	int i;
+
+	if (!tcpSocketList)
+		return 0;
+	for (i = 0; i < (int)tcpSocketList->pointer; i++) {
+		AuSocket* sock = (AuSocket*)list_get_at(tcpSocketList, i);
+		if (sock && sock->sessionPort == port)
+			return 1;
+	}
 	return 0;
 }
 
-/*
-* AuTCPSend -- TCP protocol send interface
-* @param sock -- Pointer to socket
-* @param msghdr -- Message header containing every information
-* @param flags -- extra flags
-*/
-int AuTCPSend(AuSocket* sock, msghdr* msg, int flags) {
-	return 0;
-}
+static void TCPRegisterSocket(AuSocket* sock) {
+	int i;
 
-/*
-* AuTCPClose -- TCP protocol close call
-* @param sock -- Pointer to socket
-*/
-void AuTCPClose(AuSocket* sock) {
-	return;
-}
-
-static int _tcp_port_ = 49152;
-/*
- * AuTCPObtainPort -- obtains a new port for
- * a session, port number 0 - 1024 are reserved
- * for services and protocols like HTTP(port 80)
- * FTP(port 21), SSH(port 22)..etc
- * Rage from 1024 to 49151 are assigned by Internet
- * Assigned Numbers Authority for specific services
- * upon application by a requesting entity.
- * Dynamic/Private ports ranges from 49152 - 65535
- * this ports are not assigned and can be used
- * dynamically by applications and services
- * @param sock -- Pointer to socket session
- */
-void AuTCPObtainPort(AuSocket* sock) {
-	int port = _tcp_port_++;
-	sock->sessionPort = port;
+	if (!tcpSocketList || !sock)
+		return;
+	for (i = 0; i < (int)tcpSocketList->pointer; i++) {
+		if (list_get_at(tcpSocketList, i) == sock)
+			return;
+	}
 	list_add(tcpSocketList, sock);
 }
 
-/*
- * AuTCPAcknowledge -- send ack packets
- * @param nic -- Pointer to NIC device
- * @param sock -- Pointer to session socket
- * @param ippack -- Pointer to IPv4 packet
- * @param payloadLen -- length of the payload
-*/
-int AuTCPAcknowledge(AuVFSNode* nic, AuSocket* sock, IPv4Header* ippack, size_t payloadLen) {
-	AuNetworkDevice* nicdev = (AuNetworkDevice*)nic->device;
-	if (!nicdev)
+static void TCPUnregisterSocket(AuSocket* sock) {
+	int i;
+
+	if (!tcpSocketList || !sock)
+		return;
+	for (i = 0; i < (int)tcpSocketList->pointer; i++) {
+		if (list_get_at(tcpSocketList, i) == sock) {
+			list_remove(tcpSocketList, i);
+			return;
+		}
+	}
+}
+
+static void AuTCPObtainPort(AuSocket* sock) {
+	int tries = 0;
+
+	while (tries < 16384) {
+		int port = _tcp_port_++;
+		if (_tcp_port_ > 65535)
+			_tcp_port_ = 49152;
+		if (!TCPPortInUse((uint16_t)port)) {
+			sock->sessionPort = (uint16_t)port;
+			TCPRegisterSocket(sock);
+			return;
+		}
+		tries++;
+	}
+	sock->sessionPort = (uint16_t)_tcp_port_++;
+	TCPRegisterSocket(sock);
+}
+
+static int TCPSendSegment(AuSocket* sock, uint16_t flags, const void* payload, size_t payloadLen) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	AuNetworkDevice* ndev;
+	IPv4Header* ipv4;
+	TCPHeader* tcp;
+	TCPCheckHeader checkhdr;
+	size_t totalLen;
+	uint32_t seq;
+
+	if (!pcb || !pcb->nic)
+		return -1;
+	ndev = (AuNetworkDevice*)pcb->nic->device;
+	if (!ndev)
 		return -1;
 
-	/*  need to implement three way ack to handle
-	 * packet loss or errors
-	 */
-	TCPHeader* tcp = (TCPHeader*)&ippack->payload;
-	int windowsz = TCP_DEFAULT_WIN_SZ;
+	totalLen = sizeof(IPv4Header) + sizeof(TCPHeader) + payloadLen;
+	ipv4 = (IPv4Header*)kmalloc(totalLen);
+	if (!ipv4)
+		return -1;
+	memset(ipv4, 0, totalLen);
 
-	unsigned seq_num = sock->packID + 1;
-	unsigned ack_num = (tcp->sequenceNum + payloadLen);
-	size_t totalLen = sizeof(IPv4Header) + sizeof(TCPHeader);
-	IPv4Header* ipv4 = (IPv4Header*)kmalloc(totalLen);
-	ipv4->totalLength = htons(totalLen);
-	ipv4->destAddress = ippack->srcAddress;
-	ipv4->srcAddress = nicdev->ipv4addr;
-	ipv4->timeToLive = 64;
-	ipv4->protocol = IPV4_PROTOCOL_TCP;
+	ipv4->versionHeaderLen = 0x45;
+	ipv4->typeOfService = 0;
+	ipv4->totalLength = htons((uint16_t)totalLen);
 	sock->ipv4Iden++;
 	ipv4->identification = htons(sock->ipv4Iden);
-	ipv4->flagsFragOffset = htons(0x0);
-	ipv4->versionHeaderLen = 0x45;
-	ipv4->typeOfService = 0;
-	ipv4->headerChecksum = htons(IPv4CalculateChecksum(ipv4));
-
-	/* handle fin packets */
-	int flags = TCP_FLAGS_ACK;
-
-	TCPHeader* tcppack = (TCPHeader*)&ipv4->payload;
-	tcppack->srcPort = htons(sock->sessionPort);
-	tcppack->destPort = tcp->srcPort;
-	tcppack->sequenceNum = htonl(seq_num);
-	tcppack->ackNum = htonl(ack_num);
-	tcppack->dataOffsetFlags = htons(flags | 0x5000);
-	tcppack->window = htons(windowsz);
-	tcppack->checksum = 0;
-	tcppack->urgentPointer = 0;
-
-	TCPCheckHeader checkhdr;
-	checkhdr.source = ipv4->srcAddress;
-	checkhdr.destination = ipv4->destAddress;
-	checkhdr.zeros = 0;
-	checkhdr.protocol = IPV4_PROTOCOL_TCP;
-	checkhdr.tcpLen = htons(sizeof(TCPHeader));
-
-	tcppack->checksum = htons(CalculateTCPChecksum(&checkhdr, tcppack, NULL, 0));
-	IPV4SendPacket(ipv4, nic);
-	UARTDebugOut("TCP-ACK Sent !! successfully \r\n");
-	kfree(ipv4);
-	return 0;
-}
-/*
-* AuTCPConnect -- TCP protocol connect interface
-* @param sock -- Pointer to socket
-* @param addr -- socket address information
-* @param addrlen -- address length
-*/
-int AuTCPConnect(AuSocket* sock, sockaddr* addr, socklen_t addrlen) {
-	sockaddr_in* sockdata = (sockaddr_in*)addr;
-	UARTDebugOut("TCP connect call called \r\n");
-	AuTCPObtainPort(sock);
-	int sourcePort = sock->sessionPort;
-	sock->sockState = SOCK_STATE_WAITING_FOR_CONNECTION;
-	sock->ipv4Iden = rand();
-	AuVFSNode* nic = AuNetworkRoute(sockdata->sin_addr.s_addr);
-	if (!nic) {
-		UARTDebugOut("[Aurora-net]: TCP failed to connect, no NIC\r\n");
-		return 1;
-	}
-
-	AuNetworkDevice* ndev = (AuNetworkDevice*)nic->device;
-	if (!ndev) {
-		UARTDebugOut("[Aurora-net]: TCP No Netword device data \r\n");
-		return 1;
-	}
-
-	size_t totalLen = sizeof(IPv4Header) + sizeof(TCPHeader);
-
-	/* IPV4 Header */
-	IPv4Header* ipv4 = (IPv4Header*)kmalloc(totalLen);
-	ipv4->totalLength = htons(totalLen);
-	ipv4->destAddress = sockdata->sin_addr.s_addr;
-	ipv4->srcAddress = ndev->ipv4addr;
+	ipv4->flagsFragOffset = htons(0x4000);
 	ipv4->timeToLive = 64;
 	ipv4->protocol = IPV4_PROTOCOL_TCP;
-	ipv4->identification = htons(sock->ipv4Iden);
-	ipv4->flagsFragOffset = htons(0x0);
-	ipv4->versionHeaderLen = 0x45;
-	ipv4->typeOfService = 0;
+	ipv4->srcAddress = ndev->ipv4addr;
+	ipv4->destAddress = pcb->remote_ip;
+	ipv4->headerChecksum = 0;
 	ipv4->headerChecksum = htons(IPv4CalculateChecksum(ipv4));
 
-	TCPHeader* tcp = (TCPHeader*)&ipv4->payload;
+	seq = pcb->snd_nxt;
+	tcp = (TCPHeader*)&ipv4->payload;
 	tcp->srcPort = htons(sock->sessionPort);
-	tcp->destPort = sockdata->sin_port;
-	tcp->sequenceNum = 0;
-	tcp->ackNum = 0;
-	tcp->dataOffsetFlags = htons((1 << 1) | 0x5000);
-	tcp->window = htons(TCP_DEFAULT_WIN_SZ);
+	tcp->destPort = htons(pcb->remote_port);
+	tcp->sequenceNum = htonl(seq);
+	tcp->ackNum = htonl(pcb->rcv_nxt);
+	tcp->dataOffsetFlags = htons(flags | 0x5000);
+	tcp->window = htons(TCPWindowOf(sock));
 	tcp->checksum = 0;
 	tcp->urgentPointer = 0;
-	sock->packID = tcp->sequenceNum;
+	if (payload && payloadLen)
+		memcpy(&ipv4->payload[sizeof(TCPHeader)], (void*)payload, payloadLen);
 
-	TCPHeader* tcpch = (TCPHeader*)ipv4->payload;
-	UARTDebugOut("TCP Check SRC -> %d \r\n", tcpch->srcPort);
+	checkhdr.source = ipv4->srcAddress;
+	checkhdr.destination = ipv4->destAddress;
+	checkhdr.zeros = 0;
+	checkhdr.protocol = IPV4_PROTOCOL_TCP;
+	checkhdr.tcpLen = htons((uint16_t)(sizeof(TCPHeader) + payloadLen));
+	tcp->checksum = htons(CalculateTCPChecksum(&checkhdr, tcp,
+		payloadLen ? &ipv4->payload[sizeof(TCPHeader)] : NULL, payloadLen));
 
+	IPV4SendPacket(ipv4, pcb->nic);
+	kfree(ipv4);
+
+	if (flags & TCP_FLAGS_SYN)
+		pcb->snd_nxt = seq + 1;
+	else {
+		pcb->snd_nxt = seq + (uint32_t)payloadLen;
+		if (flags & TCP_FLAGS_FIN)
+			pcb->snd_nxt += 1;
+	}
+	return 0;
+}
+
+static void TCPSendReset(AuVFSNode* nic, IPv4Header* ip, TCPHeader* tcp, size_t segLen) {
+	AuNetworkDevice* ndev;
+	IPv4Header* ipv4;
+	TCPHeader* rst;
 	TCPCheckHeader checkhdr;
+	uint16_t flags;
+	uint32_t seq;
+	uint32_t ack;
+	size_t totalLen;
+
+	if (!nic)
+		return;
+	ndev = (AuNetworkDevice*)nic->device;
+	if (!ndev)
+		return;
+
+	flags = TCPFlagsOf(tcp);
+	if (flags & TCP_FLAGS_RST)
+		return;
+
+	totalLen = sizeof(IPv4Header) + sizeof(TCPHeader);
+	ipv4 = (IPv4Header*)kmalloc(totalLen);
+	if (!ipv4)
+		return;
+	memset(ipv4, 0, totalLen);
+
+	ipv4->versionHeaderLen = 0x45;
+	ipv4->totalLength = htons((uint16_t)totalLen);
+	ipv4->identification = 0;
+	ipv4->flagsFragOffset = htons(0x4000);
+	ipv4->timeToLive = 64;
+	ipv4->protocol = IPV4_PROTOCOL_TCP;
+	ipv4->srcAddress = ndev->ipv4addr;
+	ipv4->destAddress = ip->srcAddress;
+	ipv4->headerChecksum = 0;
+	ipv4->headerChecksum = htons(IPv4CalculateChecksum(ipv4));
+
+	if (flags & TCP_FLAGS_ACK) {
+		seq = ntohl(tcp->ackNum);
+		ack = 0;
+		flags = TCP_FLAGS_RST;
+	} else {
+		seq = 0;
+		ack = ntohl(tcp->sequenceNum) + (uint32_t)segLen;
+		flags = TCP_FLAGS_RST | TCP_FLAGS_ACK;
+	}
+
+	rst = (TCPHeader*)&ipv4->payload;
+	rst->srcPort = tcp->destPort;
+	rst->destPort = tcp->srcPort;
+	rst->sequenceNum = htonl(seq);
+	rst->ackNum = htonl(ack);
+	rst->dataOffsetFlags = htons(flags | 0x5000);
+	rst->window = 0;
+	rst->checksum = 0;
+	rst->urgentPointer = 0;
+
 	checkhdr.source = ipv4->srcAddress;
 	checkhdr.destination = ipv4->destAddress;
 	checkhdr.zeros = 0;
 	checkhdr.protocol = IPV4_PROTOCOL_TCP;
 	checkhdr.tcpLen = htons(sizeof(TCPHeader));
-
-	tcp->checksum = htons(CalculateTCPChecksum(&checkhdr, tcp, NULL, 0));
-
+	rst->checksum = htons(CalculateTCPChecksum(&checkhdr, rst, NULL, 0));
 	IPV4SendPacket(ipv4, nic);
+	kfree(ipv4);
+}
 
+static void TCPFreePCB(TCPControlBlock* pcb) {
+	if (!pcb)
+		return;
+	if (pcb->rxbuf) {
+		AuCircBufFree((CircBuffer*)pcb->rxbuf);
+		pcb->rxbuf = NULL;
+	}
+	if (pcb->rxmem) {
+		kfree(pcb->rxmem);
+		pcb->rxmem = NULL;
+	}
+	if (pcb->acceptq) {
+		while (pcb->acceptq->pointer)
+			list_remove(pcb->acceptq, 0);
+		kfree(pcb->acceptq);
+		pcb->acceptq = NULL;
+	}
+	kfree(pcb);
+}
+
+static TCPControlBlock* TCPAllocPCB(void) {
+	TCPControlBlock* pcb = (TCPControlBlock*)kmalloc(sizeof(TCPControlBlock));
+	if (!pcb)
+		return NULL;
+	memset(pcb, 0, sizeof(TCPControlBlock));
+	pcb->state = TCP_STATE_CLOSED;
+	pcb->mss = TCP_MSS;
+	pcb->snd_wnd = TCP_DEFAULT_WIN_SZ;
+	pcb->rcv_wnd = TCP_RX_BUF_SZ;
+	pcb->rxmem = (uint8_t*)kmalloc(TCP_RX_BUF_SZ);
+	if (!pcb->rxmem) {
+		kfree(pcb);
+		return NULL;
+	}
+	memset(pcb->rxmem, 0, TCP_RX_BUF_SZ);
+	pcb->rxbuf = AuCircBufInitialise(pcb->rxmem, TCP_RX_BUF_SZ);
+	if (!pcb->rxbuf) {
+		kfree(pcb->rxmem);
+		kfree(pcb);
+		return NULL;
+	}
+	return pcb;
+}
+
+static AuSocket* TCPAllocSocket(void);
+int AuTCPBind(AuSocket* sock, sockaddr* addr, socklen_t addrlen);
+int AuTCPListen(AuSocket* sock, int backlog);
+int AuTCPAccept(AuSocket* sock, sockaddr* addr, socklen_t* addrlen);
+int AuTCPReceive(AuSocket* sock, msghdr* msg, int flags);
+int AuTCPSend(AuSocket* sock, msghdr* msg, int flags);
+void AuTCPClose(AuSocket* sock);
+int AuTCPConnect(AuSocket* sock, sockaddr* addr, socklen_t addrlen);
+int AuTCPFileClose(AuVFSNode* fsys, AuVFSNode* file);
+
+static AuSocket* TCPAllocSocket(void) {
+	AuSocket* sock = AuNetCreateSocket();
+	TCPControlBlock* pcb;
+
+	if (!sock)
+		return NULL;
+	pcb = TCPAllocPCB();
+	if (!pcb) {
+		if (sock->rxstack)
+			kfree(sock->rxstack);
+		kfree(sock);
+		return NULL;
+	}
+	sock->send = AuTCPSend;
+	sock->receive = AuTCPReceive;
+	sock->connect = AuTCPConnect;
+	sock->bind = AuTCPBind;
+	sock->close = AuTCPClose;
+	sock->listen = AuTCPListen;
+	sock->accept = AuTCPAccept;
+	sock->proto = pcb;
+	sock->sockState = SOCK_STATE_CLOSED;
+	return sock;
+}
+
+static AuSocket* TCPFindSocket(uint32_t srcIP, uint16_t srcPort, uint16_t destPort) {
+	AuSocket* listener = NULL;
+	int i;
+
+	if (!tcpSocketList)
+		return NULL;
+	for (i = 0; i < (int)tcpSocketList->pointer; i++) {
+		AuSocket* sock = (AuSocket*)list_get_at(tcpSocketList, i);
+		TCPControlBlock* pcb;
+
+		if (!sock || sock->sessionPort != destPort)
+			continue;
+		pcb = TCPGetPCB(sock);
+		if (!pcb)
+			continue;
+		if (pcb->state == TCP_STATE_LISTEN) {
+			listener = sock;
+			continue;
+		}
+		if (pcb->remote_ip == srcIP && pcb->remote_port == srcPort)
+			return sock;
+	}
+	return listener;
+}
+
+static void TCPQueueAccept(AuSocket* listener, AuSocket* child) {
+	TCPControlBlock* pcb = TCPGetPCB(listener);
+
+	if (!pcb)
+		return;
+	if (!pcb->acceptq)
+		pcb->acceptq = initialize_list();
+	if (pcb->acceptq)
+		list_add(pcb->acceptq, child);
+}
+
+static int TCPWriteRx(TCPControlBlock* pcb, const uint8_t* data, size_t len) {
+	size_t i;
+	CircBuffer* buf;
+
+	if (!pcb || !pcb->rxbuf || !data || !len)
+		return 0;
+	buf = (CircBuffer*)pcb->rxbuf;
+	for (i = 0; i < len; i++) {
+		if (AuCircBufPut(buf, data[i]) != 0)
+			return (int)i;
+	}
+	return (int)len;
+}
+
+static int TCPSendAck(AuSocket* sock) {
+	return TCPSendSegment(sock, TCP_FLAGS_ACK, NULL, 0);
+}
+
+int AuTCPAcknowledge(AuVFSNode* nic, AuSocket* sock, IPv4Header* ippack, size_t payloadLen) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	TCPHeader* tcp;
+
+	if (!pcb || !ippack)
+		return -1;
+	if (!pcb->nic)
+		pcb->nic = nic;
+	tcp = (TCPHeader*)&ippack->payload;
+	pcb->rcv_nxt = ntohl(tcp->sequenceNum) + (uint32_t)payloadLen;
+	return TCPSendAck(sock);
+}
+
+int AuTCPReceive(AuSocket* sock, msghdr* msg, int flags) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	CircBuffer* buf;
+	size_t want;
+	size_t got = 0;
+	uint8_t* dest;
+
+	(void)flags;
+	if (!pcb)
+		return -1;
+	if (!msg || msg->msg_iovlen == 0)
+		return 0;
+	if (msg->msg_iovlen > 1)
+		return -1;
+
+	buf = (CircBuffer*)pcb->rxbuf;
+	want = msg->msg_iov[0].iov_len;
+	dest = (uint8_t*)msg->msg_iov[0].iov_base;
+	if (!buf || CircBufEmpty(buf)) {
+		if (pcb->fin_recvd || pcb->state == TCP_STATE_CLOSE_WAIT ||
+			pcb->state == TCP_STATE_CLOSED)
+			return 0;
+		return -1;
+	}
+
+	while (got < want && !CircBufEmpty(buf)) {
+		if (AuCircBufGet(buf, dest + got) != 0)
+			break;
+		got++;
+	}
+
+	if (msg->msg_name && msg->msg_namelen >= sizeof(sockaddr_in)) {
+		sockaddr_in* in = (sockaddr_in*)msg->msg_name;
+		in->sin_family = AF_INET;
+		in->sin_port = htons(pcb->remote_port);
+		in->sin_addr.s_addr = pcb->remote_ip;
+		msg->msg_namelen = sizeof(sockaddr_in);
+	}
+	return (int)got;
+}
+
+int AuTCPSend(AuSocket* sock, msghdr* msg, int flags) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	const uint8_t* src;
+	size_t remaining;
+	size_t sent = 0;
+
+	(void)flags;
+	if (!pcb)
+		return -1;
+	if (pcb->state != TCP_STATE_ESTABLISHED && pcb->state != TCP_STATE_CLOSE_WAIT)
+		return -1;
+	if (!msg || msg->msg_iovlen == 0)
+		return 0;
+	if (msg->msg_iovlen > 1)
+		return -1;
+
+	src = (const uint8_t*)msg->msg_iov[0].iov_base;
+	remaining = msg->msg_iov[0].iov_len;
+	while (remaining) {
+		size_t chunk = remaining;
+		uint16_t sendFlags = TCP_FLAGS_ACK | TCP_FLAGS_PSH;
+		if (chunk > pcb->mss)
+			chunk = pcb->mss;
+		if (TCPSendSegment(sock, sendFlags, src + sent, chunk) != 0)
+			break;
+		sent += chunk;
+		remaining -= chunk;
+	}
+	return (int)sent;
+}
+
+void AuTCPClose(AuSocket* sock) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+
+	if (!pcb)
+		return;
+	if (pcb->state == TCP_STATE_ESTABLISHED || pcb->state == TCP_STATE_SYN_RECEIVED) {
+		TCPSendSegment(sock, TCP_FLAGS_FIN | TCP_FLAGS_ACK, NULL, 0);
+		pcb->state = TCP_STATE_FIN_WAIT_1;
+	} else if (pcb->state == TCP_STATE_CLOSE_WAIT) {
+		TCPSendSegment(sock, TCP_FLAGS_FIN | TCP_FLAGS_ACK, NULL, 0);
+		pcb->state = TCP_STATE_LAST_ACK;
+	} else if (pcb->state == TCP_STATE_LISTEN) {
+		int i;
+		pcb->state = TCP_STATE_CLOSED;
+		if (tcpSocketList) {
+			for (i = (int)tcpSocketList->pointer - 1; i >= 0; i--) {
+				AuSocket* child = (AuSocket*)list_get_at(tcpSocketList, i);
+				TCPControlBlock* childpcb = TCPGetPCB(child);
+				if (childpcb && childpcb->parent == sock) {
+					TCPSendSegment(child, TCP_FLAGS_RST | TCP_FLAGS_ACK, NULL, 0);
+					childpcb->state = TCP_STATE_CLOSED;
+				}
+			}
+		}
+	} else if (pcb->state != TCP_STATE_CLOSED && pcb->state != TCP_STATE_TIME_WAIT) {
+		TCPSendSegment(sock, TCP_FLAGS_RST | TCP_FLAGS_ACK, NULL, 0);
+		pcb->state = TCP_STATE_CLOSED;
+	}
+}
+
+int AuTCPConnect(AuSocket* sock, sockaddr* addr, socklen_t addrlen) {
+	sockaddr_in* sockdata = (sockaddr_in*)addr;
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	AuVFSNode* nic;
+	AuNetworkDevice* ndev;
 	uint64_t s, ss = 0;
 	uint64_t ns, nss = 0;
-	aa64_calculate_ticks(1, 0, &s, &ss);
 	int attempts = 0;
-	while (!sock->rxstack->itemCount) {
+
+	(void)addrlen;
+	if (!pcb || !sockdata)
+		return -1;
+
+	UARTDebugOut("[aurora]: TCP connect \r\n");
+	if (sock->sessionPort == 0)
+		AuTCPObtainPort(sock);
+	else
+		TCPRegisterSocket(sock);
+
+	nic = AuNetworkRoute(sockdata->sin_addr.s_addr);
+	if (!nic) {
+		UARTDebugOut("[aurora]: TCP connect, no NIC\r\n");
+		return -1;
+	}
+	ndev = (AuNetworkDevice*)nic->device;
+	if (!ndev) {
+		UARTDebugOut("[aurora]: TCP connect, no NIC data\r\n");
+		return -1;
+	}
+
+	pcb->nic = nic;
+	pcb->remote_ip = sockdata->sin_addr.s_addr;
+	pcb->remote_port = ntohs(sockdata->sin_port);
+	pcb->iss = ((uint32_t)rand() << 16) ^ (uint32_t)rand();
+	if (pcb->iss == 0)
+		pcb->iss = 1;
+	pcb->snd_una = pcb->iss;
+	pcb->snd_nxt = pcb->iss;
+	pcb->rcv_nxt = 0;
+	sock->ipv4Iden = (uint16_t)rand();
+	sock->sockState = SOCK_STATE_WAITING_FOR_CONNECTION;
+	pcb->state = TCP_STATE_SYN_SENT;
+
+	if (TCPSendSegment(sock, TCP_FLAGS_SYN, NULL, 0) != 0)
+		return -1;
+
+	aa64_calculate_ticks(1, 0, &s, &ss);
+	while (pcb->state == TCP_STATE_SYN_SENT) {
 		AuSleepThread(AuGetCurrentThread(), 20);
 		AuScheduleNext();
-
 		aa64_calculate_ticks(0, 0, &ns, &nss);
-		//connection refused
+
 		if (sock->sockState == SOCK_STATE_CONNECTION_RST) {
-			UARTDebugOut("Sock state reset \r\n");
-			kfree(ipv4);
+			UARTDebugOut("[aurora]: TCP connection reset\r\n");
 			return -1;
 		}
 		if ((ns > s || (ns == s && nss > ss))) {
 			if (attempts == 3) {
-				UARTDebugOut("Attempts == 3 \r\n");
-				kfree(ipv4);
-				return -1; //timeout
+				UARTDebugOut("[aurora]: TCP connect timeout\r\n");
+				pcb->state = TCP_STATE_CLOSED;
+				return -1;
 			}
-			UARTDebugOut("[aurora]: TCP retrying connection \r\n");
-			IPV4SendPacket(ipv4, nic);
+			UARTDebugOut("[aurora]: TCP retrying connection\r\n");
+			pcb->snd_nxt = pcb->iss;
+			TCPSendSegment(sock, TCP_FLAGS_SYN, NULL, 0);
 			aa64_calculate_ticks(1, 0, &s, &ss);
 			attempts++;
 		}
 	}
-	kfree(ipv4);
-	UARTDebugOut("[aurora]: TCP connection succeeded \r\n");
+
+	if (pcb->state != TCP_STATE_ESTABLISHED) {
+		UARTDebugOut("[aurora]: TCP connect failed, state %d\r\n", pcb->state);
+		return -1;
+	}
+	sock->sockState = SOCK_STATE_CONNECTED;
+	UARTDebugOut("[aurora]: TCP connection succeeded\r\n");
 	return 0;
 }
 
 int AuTCPBind(AuSocket* sock, sockaddr* addr, socklen_t addrlen) {
+	sockaddr_in* addr_in = (sockaddr_in*)addr;
+	int port;
+	int i;
+
+	(void)addrlen;
+	if (!addr_in)
+		return -1;
+	if (sock->sessionPort != 0)
+		return -1;
+
+	port = ntohs(addr_in->sin_port);
+	if (port == 0) {
+		AuTCPObtainPort(sock);
+		return 0;
+	}
+	if (!tcpSocketList)
+		return -1;
+	for (i = 0; i < (int)tcpSocketList->pointer; i++) {
+		AuSocket* other = (AuSocket*)list_get_at(tcpSocketList, i);
+		TCPControlBlock* pcb = TCPGetPCB(other);
+		if (other && other->sessionPort == (uint16_t)port && pcb &&
+			pcb->state == TCP_STATE_LISTEN)
+			return -1;
+	}
+	sock->sessionPort = (uint16_t)port;
+	TCPRegisterSocket(sock);
+	UARTDebugOut("[aurora]: TCP bound to port %d\r\n", port);
 	return 0;
 }
 
-uint64_t AuTCPRead(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t len) {
+int AuTCPListen(AuSocket* sock, int backlog) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+
+	if (!pcb)
+		return -1;
+	if (sock->sessionPort == 0)
+		return -1;
+	if (backlog <= 0)
+		backlog = 1;
+	pcb->backlog = backlog;
+	if (!pcb->acceptq)
+		pcb->acceptq = initialize_list();
+	pcb->state = TCP_STATE_LISTEN;
+	sock->sockState = SOCK_STATE_CONNECTED;
+	UARTDebugOut("[aurora]: TCP listen on %d\r\n", sock->sessionPort);
 	return 0;
 }
 
-uint64_t AuTCPWrite(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, uint32_t len) {
-	return 0;
+int AuTCPAccept(AuSocket* sock, sockaddr* addr, socklen_t* addrlen) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	AuSocket* child = NULL;
+	TCPControlBlock* childpcb;
+	AA64Thread* thread;
+	AuProcess* proc;
+	AuVFSNode* node;
+	int fd;
+	uint64_t s, ss = 0;
+	uint64_t ns, nss = 0;
+
+	if (!pcb || pcb->state != TCP_STATE_LISTEN || !pcb->acceptq)
+		return -1;
+
+	aa64_calculate_ticks(30, 0, &s, &ss);
+	while (pcb->acceptq->pointer == 0) {
+		AuSleepThread(AuGetCurrentThread(), 20);
+		AuScheduleNext();
+		aa64_calculate_ticks(0, 0, &ns, &nss);
+		if (ns > s || (ns == s && nss > ss))
+			return -1;
+	}
+
+	child = (AuSocket*)list_remove(pcb->acceptq, 0);
+	if (!child)
+		return -1;
+	childpcb = TCPGetPCB(child);
+	thread = AuGetCurrentThread();
+	if (!thread)
+		return -1;
+	proc = AuProcessFindThread(thread);
+	if (!proc)
+		proc = AuProcessFindSubThread(thread);
+	if (!proc)
+		return -1;
+
+	fd = AuProcessGetFileDesc(proc);
+	node = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
+	if (!node)
+		return -1;
+	memset(node, 0, sizeof(AuVFSNode));
+	strcpy(node->filename, "tcp");
+	node->flags |= FS_FLAG_SOCKET;
+	node->device = child;
+	node->close = AuTCPFileClose;
+	node->iocontrol = SocketIOControl;
+	proc->fds[fd] = node;
+
+	if (addr && addrlen && *addrlen >= sizeof(sockaddr_in) && childpcb) {
+		sockaddr_in* in = (sockaddr_in*)addr;
+		in->sin_family = AF_INET;
+		in->sin_port = htons(childpcb->remote_port);
+		in->sin_addr.s_addr = childpcb->remote_ip;
+		*addrlen = sizeof(sockaddr_in);
+	}
+	return fd;
+}
+
+static void TCPHandleListenSyn(AuSocket* listener, IPv4Header* pack, TCPHeader* tcp, AuVFSNode* nic) {
+	TCPControlBlock* lpcb = TCPGetPCB(listener);
+	AuSocket* child;
+	TCPControlBlock* pcb;
+	uint32_t seq;
+
+	if (!lpcb)
+		return;
+	if (lpcb->acceptq && (int)lpcb->acceptq->pointer >= lpcb->backlog) {
+		TCPSendReset(nic, pack, tcp, 1);
+		return;
+	}
+
+	child = TCPAllocSocket();
+	if (!child) {
+		TCPSendReset(nic, pack, tcp, 1);
+		return;
+	}
+	pcb = TCPGetPCB(child);
+	seq = ntohl(tcp->sequenceNum);
+	child->sessionPort = listener->sessionPort;
+	child->ipv4Iden = (uint16_t)rand();
+	pcb->nic = nic;
+	pcb->parent = listener;
+	pcb->remote_ip = pack->srcAddress;
+	pcb->remote_port = ntohs(tcp->srcPort);
+	pcb->irs = seq;
+	pcb->rcv_nxt = seq + 1;
+	pcb->iss = ((uint32_t)rand() << 16) ^ (uint32_t)rand();
+	if (pcb->iss == 0)
+		pcb->iss = 1;
+	pcb->snd_una = pcb->iss;
+	pcb->snd_nxt = pcb->iss;
+	pcb->snd_wnd = ntohs(tcp->window);
+	pcb->state = TCP_STATE_SYN_RECEIVED;
+	child->sockState = SOCK_STATE_WAITING_FOR_CONNECTION;
+	TCPRegisterSocket(child);
+	TCPSendSegment(child, TCP_FLAGS_SYN | TCP_FLAGS_ACK, NULL, 0);
+}
+
+static void TCPHandleEstablished(AuSocket* sock, IPv4Header* pack, TCPHeader* tcp,
+	const uint8_t* payload, size_t payloadLen, uint16_t flags) {
+	TCPControlBlock* pcb = TCPGetPCB(sock);
+	uint32_t seq;
+	uint32_t ack;
+	int wrote;
+	int needAck = 0;
+
+	(void)pack;
+	if (!pcb)
+		return;
+	seq = ntohl(tcp->sequenceNum);
+	ack = ntohl(tcp->ackNum);
+
+	if (flags & TCP_FLAGS_ACK) {
+		if ((int32_t)(ack - pcb->snd_una) > 0 && (int32_t)(pcb->snd_nxt - ack) >= 0)
+			pcb->snd_una = ack;
+		pcb->snd_wnd = ntohs(tcp->window);
+
+		if (pcb->state == TCP_STATE_SYN_RECEIVED && ack == pcb->snd_nxt) {
+			pcb->state = TCP_STATE_ESTABLISHED;
+			sock->sockState = SOCK_STATE_CONNECTED;
+			if (pcb->parent)
+				TCPQueueAccept(pcb->parent, sock);
+		}
+		if (pcb->state == TCP_STATE_FIN_WAIT_1 && ack == pcb->snd_nxt)
+			pcb->state = TCP_STATE_FIN_WAIT_2;
+		if (pcb->state == TCP_STATE_LAST_ACK && ack == pcb->snd_nxt)
+			pcb->state = TCP_STATE_CLOSED;
+		if (pcb->state == TCP_STATE_CLOSING && ack == pcb->snd_nxt)
+			pcb->state = TCP_STATE_TIME_WAIT;
+	}
+
+	if (pcb->state == TCP_STATE_SYN_SENT)
+		return;
+
+	if (payloadLen) {
+		if (seq != pcb->rcv_nxt) {
+			TCPSendAck(sock);
+			return;
+		}
+		wrote = TCPWriteRx(pcb, payload, payloadLen);
+		if (wrote > 0) {
+			pcb->rcv_nxt += (uint32_t)wrote;
+			needAck = 1;
+		}
+	}
+
+	if (flags & TCP_FLAGS_FIN) {
+		if (seq + (uint32_t)payloadLen == pcb->rcv_nxt || seq == pcb->rcv_nxt) {
+			pcb->rcv_nxt += 1;
+			pcb->fin_recvd = 1;
+			needAck = 1;
+			if (pcb->state == TCP_STATE_ESTABLISHED)
+				pcb->state = TCP_STATE_CLOSE_WAIT;
+			else if (pcb->state == TCP_STATE_FIN_WAIT_1)
+				pcb->state = TCP_STATE_CLOSING;
+			else if (pcb->state == TCP_STATE_FIN_WAIT_2)
+				pcb->state = TCP_STATE_TIME_WAIT;
+		}
+	}
+
+	if (needAck)
+		TCPSendAck(sock);
+}
+
+void TCPHandlePacket(IPv4Header* pack, AuVFSNode* nic) {
+	int ihl;
+	int doff;
+	uint16_t tot;
+	uint16_t destPort;
+	uint16_t srcPort;
+	uint16_t flags;
+	size_t payloadLen;
+	size_t segLen;
+	TCPHeader* tcp;
+	AuSocket* sock;
+	TCPControlBlock* pcb;
+	const uint8_t* payload;
+
+	if (!pack)
+		return;
+	ihl = (pack->versionHeaderLen & 0x0F) * 4;
+	if (ihl < 20)
+		return;
+	tcp = (TCPHeader*)((uint8_t*)pack + ihl);
+	doff = TCPHdrBytes(tcp);
+	if (doff < 20)
+		return;
+	tot = ntohs(pack->totalLength);
+	if (tot < (uint16_t)(ihl + doff))
+		return;
+	payloadLen = (size_t)tot - (size_t)ihl - (size_t)doff;
+	payload = (const uint8_t*)tcp + doff;
+	flags = TCPFlagsOf(tcp);
+	destPort = ntohs(tcp->destPort);
+	srcPort = ntohs(tcp->srcPort);
+	segLen = payloadLen;
+	if (flags & TCP_FLAGS_SYN)
+		segLen++;
+	if (flags & TCP_FLAGS_FIN)
+		segLen++;
+
+	sock = TCPFindSocket(pack->srcAddress, srcPort, destPort);
+	if (!sock) {
+		if (!(flags & TCP_FLAGS_RST))
+			TCPSendReset(nic, pack, tcp, segLen);
+		return;
+	}
+	pcb = TCPGetPCB(sock);
+	if (!pcb)
+		return;
+
+	if (flags & TCP_FLAGS_RST) {
+		sock->sockState = SOCK_STATE_CONNECTION_RST;
+		pcb->state = TCP_STATE_CLOSED;
+		return;
+	}
+
+	if (pcb->state == TCP_STATE_LISTEN) {
+		if (flags & TCP_FLAGS_SYN)
+			TCPHandleListenSyn(sock, pack, tcp, nic);
+		return;
+	}
+
+	if (pcb->state == TCP_STATE_SYN_SENT) {
+		if ((flags & (TCP_FLAGS_SYN | TCP_FLAGS_ACK)) == (TCP_FLAGS_SYN | TCP_FLAGS_ACK)) {
+			uint32_t ack = ntohl(tcp->ackNum);
+			if (ack != pcb->iss + 1) {
+				TCPSendReset(nic, pack, tcp, segLen);
+				return;
+			}
+			pcb->irs = ntohl(tcp->sequenceNum);
+			pcb->rcv_nxt = pcb->irs + 1;
+			pcb->snd_una = ack;
+			pcb->snd_wnd = ntohs(tcp->window);
+			if (!pcb->nic)
+				pcb->nic = nic;
+			pcb->state = TCP_STATE_ESTABLISHED;
+			sock->sockState = SOCK_STATE_CONNECTED;
+			TCPSendAck(sock);
+			return;
+		}
+		if (flags & TCP_FLAGS_SYN) {
+			pcb->irs = ntohl(tcp->sequenceNum);
+			pcb->rcv_nxt = pcb->irs + 1;
+			pcb->state = TCP_STATE_SYN_RECEIVED;
+			pcb->snd_nxt = pcb->iss;
+			TCPSendSegment(sock, TCP_FLAGS_SYN | TCP_FLAGS_ACK, NULL, 0);
+			return;
+		}
+		return;
+	}
+
+	TCPHandleEstablished(sock, pack, tcp, payload, payloadLen, flags);
 }
 
 int AuTCPFileClose(AuVFSNode* fsys, AuVFSNode* file) {
-	AuSocket* sock = (AuSocket*)file->device;
+	AuSocket* sock;
+
+	(void)fsys;
+	if (!file)
+		return 0;
+	sock = (AuSocket*)file->device;
 	if (sock) {
+		AuTCPClose(sock);
+		TCPUnregisterSocket(sock);
 		if (sock->rxstack) {
 			while (sock->rxstack->itemCount) {
 				void* data = AuStackPop(sock->rxstack);
@@ -328,56 +968,50 @@ int AuTCPFileClose(AuVFSNode* fsys, AuVFSNode* file) {
 			}
 			kfree(sock->rxstack);
 		}
+		TCPFreePCB(TCPGetPCB(sock));
+		sock->proto = NULL;
 		kfree(sock);
 	}
 	kfree(file);
-	UARTDebugOut("TCP/IP Socket Closed \r\n");
+	UARTDebugOut("[aurora]: TCP socket closed\r\n");
 	return 0;
 }
-/*
- * CreateTCPSocket -- creates a new TCP Socket
- */
+
 int CreateTCPSocket() {
 	int fd = -1;
 	AA64Thread* thread = AuGetCurrentThread();
+	AuProcess* proc;
+	AuSocket* sock;
+	AuVFSNode* node;
+
 	if (!thread)
 		return -1;
-	AuProcess* proc = AuProcessFindThread(thread);
+	proc = AuProcessFindThread(thread);
 	if (!proc)
 		proc = AuProcessFindSubThread(thread);
 	if (!proc)
 		return -1;
-	AuSocket* sock = (AuSocket*)kmalloc(sizeof(AuSocket));
-	memset(sock, 0, sizeof(AuSocket));
-	sock->send = AuTCPSend;
-	sock->receive = AuTCPReceive;
-	sock->connect = AuTCPConnect;
-	sock->bind = AuTCPBind;
-	sock->close = AuTCPClose;
-	sock->rxstack = AuStackCreate();
+	sock = TCPAllocSocket();
+	if (!sock)
+		return -1;
 	fd = AuProcessGetFileDesc(proc);
-	AuVFSNode* node = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
+	node = (AuVFSNode*)kmalloc(sizeof(AuVFSNode));
 	memset(node, 0, sizeof(AuVFSNode));
+	strcpy(node->filename, "tcp");
 	node->flags |= FS_FLAG_SOCKET;
 	node->device = sock;
 	node->close = AuTCPFileClose;
 	node->iocontrol = SocketIOControl;
 	proc->fds[fd] = node;
-	UARTDebugOut("TCP Socket created \r\n");
+	UARTDebugOut("[aurora]: TCP socket created\r\n");
 	return fd;
 }
 
-/*
- * TCPGetSocketList -- return the current socket
- * list of TCP
- */
 list_t* TCPGetSocketList() {
 	return tcpSocketList;
 }
 
-/*
- * TCPProtocolInstall -- initialize the TCP protocol
- */
 void TCPProtocolInstall() {
 	tcpSocketList = initialize_list();
+	UARTDebugOut("[aurora]: TCP protocol installed\r\n");
 }

--- a/KernelAA64/aucon.c
+++ b/KernelAA64/aucon.c
@@ -242,10 +242,15 @@ static size_t AuConsoleRead(AuVFSNode* node, AuVFSNode* file, uint64_t* buffer, 
 		c = 0;
 		if (msg.type == AU_INPUT_KEYBOARD)
 			c = AuConsoleMapKey(msg.code);
+		if (c == '\r')
+			c = '\n';
 		if (c) {
 			out[n++] = (uint8_t)c;
 			if (c == '\n')
 				break;
+		} else if (msg.type != 0) {
+			/* key-up / modifier: drain the queue, do not sleep */
+			continue;
 		} else {
 			if (n)
 				break;

--- a/KernelAA64/loader.c
+++ b/KernelAA64/loader.c
@@ -406,6 +406,26 @@ int AuLoadExecToProcess(AuProcess* proc, char* filename, int argc, char** argv) 
 	uentry->argvaddr = argvaddr;
 	uentry->argvkernel = argvkernel;
 	uentry->num_args = num_args;
+	/*
+	 * argv[] from ProcessLoadExec still points at the parent's user heap.
+	 * AuProcessEntUser runs on the child's TTBR0, so those addresses are
+	 * unmapped there (translation fault). Copy each string into kernel
+	 * memory while we still have the parent's address space.
+	 */
+	if (num_args && argv) {
+		char** kargv = (char**)kmalloc(num_args * sizeof(char*));
+		memset(kargv, 0, num_args * sizeof(char*));
+		for (int i = 0; i < num_args; i++) {
+			size_t l = argv[i] ? strlen(argv[i]) : 0;
+			kargv[i] = (char*)kmalloc(l + 1);
+			if (argv[i])
+				strcpy(kargv[i], argv[i]);
+			else
+				kargv[i][0] = 0;
+		}
+		kfree(argv);
+		argv = kargv;
+	}
 	uentry->argvs = argv;
 	thr->uentry = uentry;
 	proc->main_thread = thr;

--- a/KernelAA64/process.c
+++ b/KernelAA64/process.c
@@ -509,12 +509,12 @@ int AuProcessWaitForTermination(AuProcess* proc, int pid) {
 			}
 		} while (1);
 	} else {
-		AuProcess* proc = AuProcessFindByPID(0, pid);
-		if (!proc)
-			return -1;
+		AuProcess* child = AuProcessFindByPID(0, pid);
+		if (!child || (child->state & PROCESS_STATE_DIED) || !child->waitlist)
+			return 0;
 		AA64Thread* thr = AuGetCurrentThread();
 		AuBlockThread(thr);
-		list_add(proc->waitlist, thr);
+		list_add(child->waitlist, thr);
 		return 1;
 	}
 	return 0;

--- a/Process/XEShell/Makefile
+++ b/Process/XEShell/Makefile
@@ -1,0 +1,45 @@
+# LLVM xesh.exe for --term.
+
+TOOLCHAIN ?= gcc
+TARGET = xesh.exe
+INCLUDES = -I../../Libs/XEClib/includes -I../../Libs/XEClib/includes/c++ -I../../BaseHdr -I../../Libs/Chitralekha
+OBJDIR = obj
+CPP_OBJS = $(OBJDIR)/main.o
+S_OBJS = $(OBJDIR)/crt0_arm64.o
+OBJS = $(CPP_OBJS) $(S_OBJS)
+
+ifeq ($(TOOLCHAIN), llvm)
+    CXX = clang++
+    CC  = clang
+    LD  = clang++
+    LLVM_TARGET = -target aarch64-unknown-windows
+    CXXFLAGS = -Wall -Wextra -ffreestanding -fno-stack-protector -fno-stack-check -fno-strict-aliasing \
+               -O2 -fno-exceptions -fno-rtti $(LLVM_TARGET) \
+               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS \
+               -Wno-error=incompatible-pointer-types -Wno-error=int-conversion \
+               -Wno-implicit-function-declaration -Wno-c++11-narrowing \
+               $(INCLUDES)
+    LDFLAGS = $(LLVM_TARGET) -fuse-ld=lld -nostdlib -Wl,-entry:_aumain -Wl,-base:0x600000000 -Wl,-subsystem:native
+endif
+
+.PHONY: all clean llvm
+llvm:
+	@$(MAKE) TOOLCHAIN=llvm all
+
+all: $(TARGET)
+
+ifeq ($(TOOLCHAIN), llvm)
+$(TARGET): $(OBJS)
+	$(LD) $(LDFLAGS) $(OBJS) ../../Libs/XEClib/libXEClib.a -o $@
+endif
+
+$(OBJDIR)/main.o: main.cpp
+	@mkdir -p $(OBJDIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(OBJDIR)/crt0_arm64.o: ../../Process/Init/crt0arm64.s
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CXXFLAGS) -Wno-unused-command-line-argument -c $< -o $@
+
+clean:
+	rm -rf $(OBJDIR) $(TARGET)

--- a/Process/XEShell/main.cpp
+++ b/Process/XEShell/main.cpp
@@ -86,11 +86,7 @@ void XEShellTimerCallback(int signo) {
  */
 void XEShellWriteCurrentDir() {
 	if (_draw_shell_curdir) {
-		//OSC 133;A = prompt start
-		printf("\033]133;A\007");
-		printf("\033[32m\033[40mXEShell /$:\033[37m\033[40m");
-		/* OSC 133;B = prompt end, input starts here*/
-		printf("\033]133;B\007");
+		printf("\nXEShell %s$: ", currentDirectory ? currentDirectory : "/");
 		fflush(stdout);
 		_draw_shell_curdir = false;
 	}
@@ -112,22 +108,22 @@ void XEShellSpawn(char* string) {
 		int index = 0;
 		int j = 0;
 		int totalCharacterCount = strlen(string);
-		char** argv = (char**)malloc(10);
-		memset(argv, 0, 10);
+		char** argv = (char**)malloc(10 * sizeof(char*));
+		memset(argv, 0, 10 * sizeof(char*));
 		/* here we mainly prepare for the arguments to pass */
 		for (int i = 0; i < strlen(string) + 1; i++) {
 			if (string[i] == ' ' || string[i] == '\0') {
 				index = i;
 
-				if (_first_string_skipped) {
-					char* str = (char*)malloc(strlen(arguments));
-					memset(str, 0, strlen(arguments));
+				if (_first_string_skipped && arguments[0] != '\0') {
+					char* str = (char*)malloc(strlen(arguments) + 1);
+					memset(str, 0, strlen(arguments) + 1);
 					strcpy(str, arguments);
 					argv[argcount] = str;
 					argcount += 1;
-					j = 0;
-					memset(arguments, 0, 32);
 				}
+				j = 0;
+				memset(arguments, 0, 32);
 
 				if (!_first_string_skipped)
 					_first_string_skipped = true;
@@ -181,7 +177,9 @@ void XEShellSpawn(char* string) {
  */
 void XEShellReadLine() {
 	char c = getchar();
-	if (c == '\n') {
+	if (c == '\n' || c == '\r') {
+		printf("\n");
+		fflush(stdout);
 		_process_needed = true;
 		return;
 	}
@@ -473,13 +471,14 @@ int main(int argc, char* arv[]) {
 #endif
 
 	printf("Copyright (C) Xeneva Private Limited \n");
-	//_KeSetSignal(SIGINT, XEShellSigInterrupt);
+	fflush(stdout);
 	cmdBuf = (char*)malloc(1024);
 	memset(cmdBuf, 0, 1024);
-	currentDirectory = (char*)malloc(strlen("/"));
+	currentDirectory = (char*)malloc(2);
 	strcpy(currentDirectory, "/");
-	_process_needed = true;
+	_process_needed = false;
 	_spawnable_process = true;
+	_draw_shell_curdir = true;
 	_sig_handled = false;
 	job = 0;
 	index = 0;

--- a/Process/http/Makefile
+++ b/Process/http/Makefile
@@ -1,0 +1,45 @@
+# LLVM curl.exe — HTTP/1.0 GET/HEAD client for --term.
+
+TOOLCHAIN ?= gcc
+TARGET = curl.exe
+INCLUDES = -I../../Libs/XEClib/includes -I../../Libs/XEClib/includes/c++ -I../../BaseHdr
+OBJDIR = obj
+CPP_OBJS = $(OBJDIR)/main.o
+S_OBJS = $(OBJDIR)/crt0_arm64.o
+OBJS = $(CPP_OBJS) $(S_OBJS)
+
+ifeq ($(TOOLCHAIN), llvm)
+    CXX = clang++
+    CC  = clang
+    LD  = clang++
+    LLVM_TARGET = -target aarch64-unknown-windows
+    CXXFLAGS = -Wall -Wextra -ffreestanding -fno-stack-protector -fno-stack-check -fno-strict-aliasing \
+               -O2 -fno-exceptions -fno-rtti $(LLVM_TARGET) \
+               -DARCH_ARM64 -D__TARGET_BOARD_QEMU_VIRT__ -D_USE_DLMALLOC -D__STDC_LIMIT_MACROS \
+               -Wno-error=incompatible-pointer-types -Wno-error=int-conversion \
+               -Wno-implicit-function-declaration -Wno-c++11-narrowing \
+               $(INCLUDES)
+    LDFLAGS = $(LLVM_TARGET) -fuse-ld=lld -nostdlib -Wl,-entry:_aumain -Wl,-base:0x600000000 -Wl,-subsystem:native
+endif
+
+.PHONY: all clean llvm
+llvm:
+	@$(MAKE) TOOLCHAIN=llvm all
+
+all: $(TARGET)
+
+ifeq ($(TOOLCHAIN), llvm)
+$(TARGET): $(OBJS)
+	$(LD) $(LDFLAGS) $(OBJS) ../../Libs/XEClib/libXEClib.a -o $@
+endif
+
+$(OBJDIR)/main.o: main.cpp
+	@mkdir -p $(OBJDIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+$(OBJDIR)/crt0_arm64.o: ../../Process/Init/crt0arm64.s
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CXXFLAGS) -Wno-unused-command-line-argument -c $< -o $@
+
+clean:
+	rm -rf $(OBJDIR) $(TARGET)

--- a/Process/http/main.cpp
+++ b/Process/http/main.cpp
@@ -1,0 +1,285 @@
+/**
+* Minimal curl: HTTP/1.0 GET/HEAD over TCP (no TLS).
+**/
+
+#include <stdint.h>
+#include <_xeneva.h>
+#include <stdio.h>
+#include <sys/_keproc.h>
+#include <sys/_kefile.h>
+#include <sys/socket.h>
+#include <sys/netdb.h>
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdlib.h>
+
+static int is_prog(const char* s) {
+	if (!s || !s[0])
+		return 1;
+	if (s[0] == '/')
+		return 1;
+	if (strstr(s, ".exe"))
+		return 1;
+	return 0;
+}
+
+static void usage(void) {
+	printf("Usage: curl [options...] <url>\n");
+	printf("  curl example.com\n");
+	printf("  curl http://example.com/\n");
+	printf("  curl -v http://example.com\n");
+	printf("  curl -I example.com\n");
+	printf("  curl -o out.html example.com\n");
+	printf("\nOptions:\n");
+	printf("  -v        Verbose\n");
+	printf("  -I        HEAD request (headers only)\n");
+	printf("  -i        Include response headers\n");
+	printf("  -o <file> Write body to file\n");
+	printf("  -h        This help\n");
+	printf("\nOnly http:// (port 80) is supported. No TLS/https.\n");
+}
+
+static int parse_url(const char* url, char* host, size_t hostsz, char* path, size_t pathsz, uint16_t* port) {
+	const char* p = url;
+	*port = 80;
+	strcpy(path, "/");
+
+	if (!strncmp(p, "https://", 8))
+		return -2;
+	if (!strncmp(p, "http://", 7))
+		p += 7;
+
+	const char* slash = strchr(p, '/');
+	const char* colon = strchr(p, ':');
+	size_t hlen;
+
+	if (colon && (!slash || colon < slash)) {
+		hlen = (size_t)(colon - p);
+		int prt = 0;
+		const char* d = colon + 1;
+		while (*d >= '0' && *d <= '9') {
+			prt = prt * 10 + (*d - '0');
+			d++;
+		}
+		if (prt > 0 && prt < 65536)
+			*port = (uint16_t)prt;
+		if (*d == '/')
+			slash = d;
+		else
+			slash = NULL;
+	} else {
+		hlen = slash ? (size_t)(slash - p) : strlen(p);
+	}
+
+	if (hlen == 0 || hlen >= hostsz)
+		return -1;
+	memcpy(host, (void*)p, hlen);
+	host[hlen] = 0;
+
+	if (slash && slash[0]) {
+		if (strlen(slash) >= pathsz)
+			return -1;
+		strcpy(path, slash);
+	}
+	return 0;
+}
+
+int main(int argc, char* argv[]) {
+	int verbose = 0;
+	int head_only = 0;
+	int include_hdr = 0;
+	const char* outfile = NULL;
+	const char* url = NULL;
+	int i;
+
+	for (i = 0; i < argc; i++) {
+		const char* a = argv[i];
+		if (is_prog(a))
+			continue;
+		if (!strcmp(a, "-h") || !strcmp(a, "--help")) {
+			usage();
+			return 0;
+		}
+		if (!strcmp(a, "-v") || !strcmp(a, "--verbose")) {
+			verbose = 1;
+			continue;
+		}
+		if (!strcmp(a, "-I") || !strcmp(a, "--head")) {
+			head_only = 1;
+			include_hdr = 1;
+			continue;
+		}
+		if (!strcmp(a, "-i") || !strcmp(a, "--include")) {
+			include_hdr = 1;
+			continue;
+		}
+		if (!strcmp(a, "-o") || !strcmp(a, "--output")) {
+			if (i + 1 < argc && !is_prog(argv[i + 1])) {
+				i++;
+				outfile = argv[i];
+			}
+			continue;
+		}
+		if (a[0] == '-') {
+			fprintf(stderr, "curl: option %s: is unknown\n", a);
+			return 2;
+		}
+		if (!url)
+			url = a;
+	}
+
+	if (!url) {
+		usage();
+		return 2;
+	}
+
+	char host[128];
+	char path[256];
+	uint16_t port = 80;
+	memset(host, 0, sizeof(host));
+	memset(path, 0, sizeof(path));
+	int pu = parse_url(url, host, sizeof(host), path, sizeof(path), &port);
+	if (pu == -2) {
+		fprintf(stderr, "curl: (1) Protocol \"https\" not supported\n");
+		return 1;
+	}
+	if (pu < 0 || !host[0]) {
+		fprintf(stderr, "curl: (3) URL malformed\n");
+		return 3;
+	}
+
+	hostent* ent = gethostbyname(host);
+	if (!ent) {
+		fprintf(stderr, "curl: (6) Could not resolve host: %s\n", host);
+		return 6;
+	}
+
+	uint32_t ipaddr = *(uint32_t*)ent->h_addr_list[0];
+	in_addr in;
+	in.s_addr = ipaddr;
+	char* ipstr = inet_ntoa(in);
+
+	if (verbose)
+		fprintf(stderr, "*   Trying %s:%u...\n", ipstr, port);
+
+	int sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) {
+		fprintf(stderr, "curl: (7) Failed to create socket\n");
+		return 7;
+	}
+
+	sockaddr_in dest;
+	memset(&dest, 0, sizeof(dest));
+	dest.sin_family = AF_INET;
+	dest.sin_port = htons(port);
+	memcpy(&dest.sin_addr, &ipaddr, sizeof(uint32_t));
+
+	if (connect(sock, (sockaddr_*)&dest, sizeof(dest)) < 0) {
+		fprintf(stderr, "curl: (7) Failed to connect to %s port %u\n", host, port);
+		_KeCloseFile(sock);
+		return 7;
+	}
+
+	if (verbose) {
+		fprintf(stderr, "* Connected to %s (%s) port %u\n", host, ipstr, port);
+		fprintf(stderr, "> %s %s HTTP/1.0\n", head_only ? "HEAD" : "GET", path);
+		fprintf(stderr, "> Host: %s\n", host);
+		fprintf(stderr, "> User-Agent: curl/xeneva\n");
+		fprintf(stderr, "> Accept: */*\n");
+		fprintf(stderr, "> Connection: close\n");
+		fprintf(stderr, ">\n");
+	}
+
+	char req[512];
+	memset(req, 0, sizeof(req));
+	snprintf(req,
+			 sizeof(req),
+			 "%s %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: curl/xeneva\r\nAccept: */*\r\nConnection: close\r\n\r\n",
+			 head_only ? "HEAD" : "GET",
+			 path,
+			 host);
+
+	if (sendto(sock, req, strlen(req), 0, (sockaddr*)&dest, sizeof(dest)) < 0) {
+		fprintf(stderr, "curl: (55) Failed sending data\n");
+		_KeCloseFile(sock);
+		return 55;
+	}
+
+	FILE* out = stdout;
+	if (outfile) {
+		out = fopen(outfile, "w+");
+		if (!out) {
+			fprintf(stderr, "curl: (23) Failed writing body\n");
+			_KeCloseFile(sock);
+			return 23;
+		}
+	}
+
+	char* buf = (char*)malloc(2048);
+	if (!buf) {
+		if (outfile)
+			fclose(out);
+		_KeCloseFile(sock);
+		return 1;
+	}
+
+	int idle = 0;
+	int got_any = 0;
+	int in_body = include_hdr ? 1 : 0;
+	char tail[4];
+	int tlen = 0;
+	memset(tail, 0, sizeof(tail));
+
+	while (idle < 80) {
+		memset(buf, 0, 2048);
+		int n = recvfrom(sock, buf, 2047, 0, NULL, NULL);
+		if (n > 0) {
+			got_any = 1;
+			idle = 0;
+			int off = 0;
+			if (!in_body) {
+				for (int k = 0; k < n; k++) {
+					if (tlen < 4)
+						tail[tlen++] = buf[k];
+					else {
+						tail[0] = tail[1];
+						tail[1] = tail[2];
+						tail[2] = tail[3];
+						tail[3] = buf[k];
+					}
+					if (tlen >= 4 && tail[0] == '\r' && tail[1] == '\n' && tail[2] == '\r' &&
+						tail[3] == '\n') {
+						in_body = 1;
+						off = k + 1;
+						break;
+					}
+				}
+				if (!in_body) {
+					continue;
+				}
+			}
+			if (head_only)
+				break;
+			if (off < n)
+				fwrite(buf + off, 1, (size_t)(n - off), out);
+			fflush(out);
+			continue;
+		}
+		if (n == 0 && got_any)
+			break;
+		_KeProcessSleep(100);
+		idle++;
+	}
+
+	if (verbose && got_any)
+		fprintf(stderr, "* Closing connection\n");
+
+	if (!got_any)
+		fprintf(stderr, "curl: (28) Operation timed out\n");
+
+	free(buf);
+	if (outfile)
+		fclose(out);
+	_KeCloseFile(sock);
+	return got_any ? 0 : 28;
+}

--- a/Process/ping/main.cpp
+++ b/Process/ping/main.cpp
@@ -68,13 +68,33 @@ static uint16_t ICMPCalculateChecksum(char* payload, size_t len) {
 */
 int main(int argc, char* argv[]) {
 	printf("\n");
-	char* s = (char*)malloc(strlen("www.getxeneva.com") + 1);
-	strcpy(s, "www.getxeneva.com");
+	const char* host = NULL;
+	for (int i = 0; i < argc; i++) {
+		if (!argv[i] || argv[i][0] == '\0')
+			continue;
+		if (argv[i][0] == '/' || strstr(argv[i], ".exe"))
+			continue;
+		host = argv[i];
+		break;
+	}
+	if (!host) {
+		printf("usage: ping <host>\n");
+		printf("  ping 10.0.2.2\n");
+		printf("  ping 8.8.8.8\n");
+		printf("  ping www.getxeneva.com\n");
+		return 1;
+	}
+
+	char* s = (char*)malloc(strlen(host) + 1);
+	if (!s)
+		return 1;
+	strcpy(s, host);
 
 	hostent* ent = gethostbyname(s);
 	if (!ent) {
+		printf("ping: unknown host %s\n", s);
 		free(s);
-		_KePauseThread();
+		return 1;
 	}
 
 	char* addr = inet_ntoa(*(struct in_addr*)ent->h_addr_list[0]);

--- a/Scripts/Linux/build_and_run_qemu.sh
+++ b/Scripts/Linux/build_and_run_qemu.sh
@@ -216,15 +216,20 @@ if [ "$SKIP_BUILD" -eq 0 ]; then
         printf '%s\n' "$requested_userspace_profile" > "$USERSPACE_PROFILE_STAMP"
     fi
     if [ "$TERM" -eq 1 ]; then
-        echo "[+] Rebuilding init.exe and ping.exe for framebuffer TTY..."
+        echo "[+] Rebuilding init.exe, xesh.exe, ping.exe, and curl.exe for framebuffer TTY..."
         term_flags="-D__XENEVA_TERM__"
         if [ "$BLEED" -eq 1 ]; then
             term_flags="-D__XENEVA_BLEED__ -D__XENEVA_TERM__"
         fi
         ( cd "$REPO_ROOT/Process/Init" && make clean && make BLEED_FLAGS="$term_flags" llvm )
+        ( cd "$REPO_ROOT/Process/XEShell" && make clean && make llvm )
         ( cd "$REPO_ROOT/Process/ping" && make clean && make llvm )
+        ( cd "$REPO_ROOT/Process/http" && make clean && make llvm )
         cp -f "$REPO_ROOT/Process/Init/init.exe" "$REPO_ROOT/Resources/resources/"
+        cp -f "$REPO_ROOT/Process/XEShell/xesh.exe" "$REPO_ROOT/Resources/resources/"
         cp -f "$REPO_ROOT/Process/ping/ping.exe" "$REPO_ROOT/Resources/resources/"
+        cp -f "$REPO_ROOT/Process/http/curl.exe" "$REPO_ROOT/Resources/resources/"
+        rm -f "$REPO_ROOT/Resources/resources/http.exe"
     fi
 else
     echo "[+] --skip-build passed, reusing existing build artifacts."


### PR DESCRIPTION
## Summary
Complete the AArch64 TCP path so user-space can `connect`/`send`/`recv`, and add a small `curl` plus `--term` shell/keyboard/argv fixes so `curl example.com` can be typed and run in the QEMU framebuffer TTY.

## Changes
### Kernel TCP (AArch64)
- **Before:** TCP was compiled but not installed. `SOCK_STREAM` returned 0, send/recv were stubs, incoming TCP packets were only logged.
- **What:** Wired `TCPProtocolInstall`, `CreateTCPSocket`, and `TCPHandlePacket`. Implemented handshake, stream I/O, bind/listen/accept, and FIN/RST. Packed IPv4/TCP headers on ARM64. Hooked `listen`/`accept` syscalls to socket ops.
- **Why:** Without this, no HTTP or other TCP clients can run on the ARM kernel.

### Exec argv and wait
- **Before:** Static PE children inherited argv pointers from the parent heap; `strlen` after the address-space switch faulted. `WaitForTermination` blocked on already-dead children, so the shell never returned.
- **What:** Copy argv strings into kernel memory before `AuProcessEntUser`. If the child is missing or `PROCESS_STATE_DIED`, wait returns immediately.
- **Why:** `curl example.com` is a static binary with arguments; the previous layout crashed or hung the TTY.

### Virtio keyboard
- **Before:** Available-ring slots were not recycled, and the keyboard device was one slot, so press was overwritten by release (Enter never reached xesh).
- **What:** Return used descriptors to the available ring, cap queue size at 64, use a 512-event FIFO, drain key-ups without sleep, map Enter.
- **Why:** `--term` input is virtio-keyboard into `/dev/console`.

### curl, ping, xesh, --term
- **Before:** No HTTP client. ping always used `www.getxeneva.com`. New xesh did not print a prompt. `--term` did not pack curl/xesh.
- **What:** `curl.exe` (HTTP/1.0 GET/HEAD, `-v -I -i -o`). ping takes `<host>`. xesh draws `XEShell /$: `, skips empty argv, LLVM Makefile. `--term` rebuilds init/xesh/ping/curl.
- **Why:** Test TCP against the internet from the framebuffer TTY without a compositor.

## Compatibility
- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [x] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.

AArch64-only kernel/net/TTY behavior. x86 TCP is unchanged except shared headers (`AuSocket` listen/accept/`proto`, packed IPv4/TCP on ARM as well as x64). Static `--term` apps treat extra args as `argv[0]` unless the token looks like a `.exe` path.

## Related
Part of kernel-r&d AArch64 networking / `--term` bring-up.
