### PR TITLE
 perf(net): bulk TCP RX copy; ci: LLVM AArch64

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,4 +1,4 @@
-name: XenevaOS Build Check (MSVC & GCC)
+name: XenevaOS Build Check (LLVM/Clang AArch64)
 
 on:
   push:
@@ -8,58 +8,23 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux-gcc:
-    name: GCC (Linux / ARM64)
+  build-llvm-aarch64:
+    name: LLVM/Clang (Linux / AArch64)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Install Toolchains (GCC AArch64)
+      - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu make mtools dosfstools
+          sudo apt-get install -y clang lld make mtools dosfstools
 
-      - name: Build GNU-EFI (AArch64)
-        run: |
-          git clone https://github.com/vathpela/gnu-efi gnu-efi
-          cd gnu-efi
-          make ARCH=aarch64 CROSS_COMPILE=aarch64-linux-gnu-
+      - name: Clone gnu-efi
+        run: git clone --depth 1 https://github.com/vathpela/gnu-efi.git
 
       - name: Build Bootloader (BootAA64)
-        run: |
-          cd BootAA64
-          make
+        run: make -C BootAA64 llvm
 
       - name: Build Kernel (KernelAA64)
-        run: |
-          cd KernelAA64
-          make
-
-  build-windows-msvc:
-    name: MSVC (Windows / x64)
-    runs-on: windows-2022
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
-
-      - name: Install NASM
-        uses: ilammy/setup-nasm@v1
-
-      - name: Setup NASM Customizations for MSBuild
-        shell: pwsh
-        run: |
-          Expand-Archive -Path Resources/nasmprops.zip -DestinationPath nasmprops -Force
-          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          $vcPath = Join-Path $vsPath "MSBuild\Microsoft\VC"
-          $customizationsPaths = Get-ChildItem -Path $vcPath -Filter "BuildCustomizations" -Directory -Recurse | Select-Object -ExpandProperty FullName
-          foreach ($path in $customizationsPaths) {
-              Copy-Item nasmprops\* -Destination $path -Force -Recurse
-          }
-
-      - name: Build Solution (Aurora.sln)
-        run: |
-          msbuild Aurora.sln /p:Configuration=Debug /p:Platform=x64 /p:PlatformToolset=v143
+        run: make -C KernelAA64 llvm

--- a/BaseHdr/circbuf.h
+++ b/BaseHdr/circbuf.h
@@ -112,8 +112,13 @@ extern void AuCircBufPutData(CircBuffer* cbuf, uint8_t data);
 extern int AuCircBufPut(CircBuffer* cbuf, uint8_t data);
 
 /*
-* AuCircBufGet -- gets a data from circular
-* buffer
+ * AuCircBufWrite -- bulk write up to 'len' bytes, returns bytes written
+ */
+extern size_t AuCircBufWrite(CircBuffer* cbuf, const uint8_t* src, size_t len);
+
+/*
+ * AuCircBufGet -- gets a data from circular
+ * buffer
 * @param cbuf -- Pointer to the circular buffer
 * @param data -- Pointer to the buffer
 * where to put the data
@@ -121,7 +126,12 @@ extern int AuCircBufPut(CircBuffer* cbuf, uint8_t data);
 extern int AuCircBufGet(CircBuffer *cbuf, uint8_t *data);
 
 /*
-* CircBufEmpty -- checks if the circular
+ * AuCircBufRead -- bulk read up to 'len' bytes, returns bytes read
+ */
+extern size_t AuCircBufRead(CircBuffer* cbuf, uint8_t* dst, size_t len);
+
+/*
+ * CircBufEmpty -- checks if the circular
 * buffer is empty
 * @param cbuf -- Pointer to the circular
 * buffer

--- a/KernelAA64/Net/tcp.c
+++ b/KernelAA64/Net/tcp.c
@@ -436,17 +436,12 @@ static void TCPQueueAccept(AuSocket* listener, AuSocket* child) {
 }
 
 static int TCPWriteRx(TCPControlBlock* pcb, const uint8_t* data, size_t len) {
-	size_t i;
 	CircBuffer* buf;
 
 	if (!pcb || !pcb->rxbuf || !data || !len)
 		return 0;
 	buf = (CircBuffer*)pcb->rxbuf;
-	for (i = 0; i < len; i++) {
-		if (AuCircBufPut(buf, data[i]) != 0)
-			return (int)i;
-	}
-	return (int)len;
+	return (int)AuCircBufWrite(buf, data, len);
 }
 
 static int TCPSendAck(AuSocket* sock) {
@@ -491,11 +486,7 @@ int AuTCPReceive(AuSocket* sock, msghdr* msg, int flags) {
 		return -1;
 	}
 
-	while (got < want && !CircBufEmpty(buf)) {
-		if (AuCircBufGet(buf, dest + got) != 0)
-			break;
-		got++;
-	}
+	got = AuCircBufRead(buf, dest, want);
 
 	if (msg->msg_name && msg->msg_namelen >= sizeof(sockaddr_in)) {
 		sockaddr_in* in = (sockaddr_in*)msg->msg_name;

--- a/KernelAA64/circbuf.c
+++ b/KernelAA64/circbuf.c
@@ -31,6 +31,7 @@
 
 #include <circbuf.h>
 #include <Mm/kmalloc.h>
+#include <string.h>
 #if defined(__GNUC__) || defined(__clang__)
 #ifndef __cplusplus
 #include <stdbool.h>
@@ -144,6 +145,27 @@ int AuCircBufPut(CircBuffer* cbuf, uint8_t data) {
 	return r;
 }
 
+size_t AuCircBufWrite(CircBuffer* cbuf, const uint8_t* src, size_t len) {
+	size_t written = 0;
+	while (written < len && !CircBufFull(cbuf)) {
+		size_t avail = cbuf->max - AuCircBufSize(cbuf);
+		size_t chunk = len - written;
+		if (chunk > avail) chunk = avail;
+		if (chunk == 0) break;
+		size_t run = cbuf->max - cbuf->head;
+		if (chunk > run) {
+			memcpy(cbuf->buffer + cbuf->head, src + written, run);
+			memcpy(cbuf->buffer, src + written + run, chunk - run);
+		} else {
+			memcpy(cbuf->buffer + cbuf->head, src + written, chunk);
+		}
+		cbuf->head = (cbuf->head + chunk) % cbuf->max;
+		cbuf->full = (cbuf->head == cbuf->tail);
+		written += chunk;
+	}
+	return written;
+}
+
 /**
  * @brief AuCircBufGet -- gets a data from circular
  * buffer
@@ -160,6 +182,27 @@ int AuCircBufGet(CircBuffer* cbuf, uint8_t* data) {
 		r = 0;
 	}
 	return r;
+}
+
+size_t AuCircBufRead(CircBuffer* cbuf, uint8_t* dst, size_t len) {
+	size_t got = 0;
+	while (got < len && !CircBufEmpty(cbuf)) {
+		size_t avail = AuCircBufSize(cbuf);
+		size_t chunk = len - got;
+		if (chunk > avail) chunk = avail;
+		if (chunk == 0) break;
+		size_t run = cbuf->max - cbuf->tail;
+		if (chunk > run) {
+			memcpy(dst + got, cbuf->buffer + cbuf->tail, run);
+			memcpy(dst + got + run, cbuf->buffer, chunk - run);
+		} else {
+			memcpy(dst + got, cbuf->buffer + cbuf->tail, chunk);
+		}
+		cbuf->tail = (cbuf->tail + chunk) % cbuf->max;
+		cbuf->full = false;
+		got += chunk;
+	}
+	return got;
 }
 
 /**

--- a/Tests/bench_circbuf.c
+++ b/Tests/bench_circbuf.c
@@ -1,0 +1,283 @@
+/**
+ * Host microbench for the TCP RX ring copy.
+ *
+ * Links KernelAA64/circbuf.c. The RX write/read path matches
+ * KernelAA64/Net/tcp.c (TCPWriteRx / AuTCPReceive) as selected
+ * by -DTCP_USES_BULK.
+ *
+ * Built by Tests/bench_compare.sh.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include <time.h>
+
+#include "circbuf.h"
+
+#ifndef TCP_RX_BUF_SZ
+#define TCP_RX_BUF_SZ 16384
+#endif
+
+#ifndef TCP_MSS
+#define TCP_MSS 1460
+#endif
+
+#define RECV_SZ    4096
+#define ITERATIONS 50000
+#define WARMUP     200
+#define NOINLINE   __attribute__((noinline))
+
+void* kmalloc(unsigned int n) {
+	return malloc(n ? n : 1);
+}
+
+void kfree(void* p) {
+	free(p);
+}
+
+/* Same copy as KernelAA64/Net/tcp.c TCPWriteRx / AuTCPReceive. */
+static NOINLINE int tcp_write_rx(CircBuffer* buf, const uint8_t* data, size_t len) {
+	if (!buf || !data || !len)
+		return 0;
+#ifdef TCP_USES_BULK
+	return (int)AuCircBufWrite(buf, data, len);
+#else
+	{
+		size_t i;
+		for (i = 0; i < len; i++) {
+			if (AuCircBufPut(buf, data[i]) != 0)
+				return (int)i;
+		}
+		return (int)len;
+	}
+#endif
+}
+
+static NOINLINE int tcp_receive(CircBuffer* buf, uint8_t* dest, size_t want) {
+	if (!buf)
+		return -1;
+	if (!dest || want == 0)
+		return 0;
+	if (CircBufEmpty(buf))
+		return -1;
+#ifdef TCP_USES_BULK
+	return (int)AuCircBufRead(buf, dest, want);
+#else
+	{
+		size_t got = 0;
+		while (got < want && !CircBufEmpty(buf)) {
+			if (AuCircBufGet(buf, dest + got) != 0)
+				break;
+			got++;
+		}
+		return (int)got;
+	}
+#endif
+}
+
+static uint8_t src[TCP_RX_BUF_SZ];
+static uint8_t dst[TCP_RX_BUF_SZ];
+static volatile uint64_t sink;
+
+static double now_ns(void) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (double)ts.tv_sec * 1e9 + (double)ts.tv_nsec;
+}
+
+static CircBuffer* make_rx(uint8_t* mem) {
+	memset(mem, 0, TCP_RX_BUF_SZ);
+	return AuCircBufInitialise(mem, TCP_RX_BUF_SZ);
+}
+
+static int fail(const char* msg) {
+	fprintf(stderr, "FAIL: %s\n", msg);
+	return 1;
+}
+
+static int check_roundtrip(size_t prefill, size_t n) {
+	uint8_t* mem = malloc(TCP_RX_BUF_SZ);
+	CircBuffer* buf;
+	int rc = 0;
+
+	if (!mem)
+		return fail("malloc");
+	buf = make_rx(mem);
+	memset(dst, 0x5A, n);
+
+	if (prefill) {
+		if (tcp_write_rx(buf, src, prefill) != (int)prefill)
+			rc = fail("prefill write");
+		else if (tcp_receive(buf, dst, prefill) != (int)prefill)
+			rc = fail("prefill drain");
+	}
+	if (!rc && tcp_write_rx(buf, src, n) != (int)n)
+		rc = fail("write short");
+	if (!rc && tcp_receive(buf, dst, n) != (int)n)
+		rc = fail("read short");
+	if (!rc && memcmp(src, dst, n) != 0)
+		rc = fail("data mismatch");
+	if (!rc && !CircBufEmpty(buf))
+		rc = fail("ring not empty");
+
+	AuCircBufFree(buf);
+	free(mem);
+	return rc;
+}
+
+static int run_correctness(void) {
+	size_t sizes[] = { 1, 64, 256, 1460, 4096, TCP_RX_BUF_SZ };
+	size_t s;
+
+	for (s = 0; s < sizeof(sizes) / sizeof(sizes[0]); s++) {
+		if (check_roundtrip(0, sizes[s])) {
+			fprintf(stderr, "  linear %zu\n", sizes[s]);
+			return 1;
+		}
+		if (sizes[s] < TCP_RX_BUF_SZ &&
+		    check_roundtrip(TCP_RX_BUF_SZ - 17, sizes[s])) {
+			fprintf(stderr, "  wrap %zu\n", sizes[s]);
+			return 1;
+		}
+	}
+	printf("correctness: ok\n");
+	return 0;
+}
+
+static double time_aligned(size_t n, int iters) {
+	uint8_t* mem = malloc(TCP_RX_BUF_SZ);
+	CircBuffer* buf = make_rx(mem);
+	int i;
+	double t0, ns;
+
+	for (i = 0; i < WARMUP; i++) {
+		tcp_write_rx(buf, src, n);
+		tcp_receive(buf, dst, n);
+		sink += dst[0] + dst[n - 1];
+	}
+	AuCircBufFree(buf);
+	buf = make_rx(mem);
+
+	t0 = now_ns();
+	for (i = 0; i < iters; i++) {
+		tcp_write_rx(buf, src, n);
+		tcp_receive(buf, dst, n);
+		sink += dst[0] + dst[n - 1];
+	}
+	ns = (now_ns() - t0) / iters;
+	AuCircBufFree(buf);
+	free(mem);
+	return ns;
+}
+
+static double time_wrap(size_t n, int iters) {
+	uint8_t* mem = malloc(TCP_RX_BUF_SZ);
+	CircBuffer* buf = make_rx(mem);
+	size_t park = TCP_RX_BUF_SZ - (n / 2);
+	int i;
+	double t0, ns;
+
+	if (park == 0 || n / 2 == 0)
+		park = TCP_RX_BUF_SZ - 1;
+
+	for (i = 0; i < WARMUP; i++) {
+		buf->head = park;
+		buf->tail = park;
+		buf->full = false;
+		tcp_write_rx(buf, src, n);
+		tcp_receive(buf, dst, n);
+		sink += dst[0] + dst[n - 1];
+	}
+	t0 = now_ns();
+	for (i = 0; i < iters; i++) {
+		buf->head = park;
+		buf->tail = park;
+		buf->full = false;
+		tcp_write_rx(buf, src, n);
+		tcp_receive(buf, dst, n);
+		sink += dst[0] + dst[n - 1];
+	}
+	ns = (now_ns() - t0) / iters;
+	AuCircBufFree(buf);
+	free(mem);
+	return ns;
+}
+
+/* NIC posts MSS segments; user recv()s 4 KiB. Ring stays occupied and wraps. */
+static double time_tcp_like(int iters) {
+	uint8_t* mem = malloc(TCP_RX_BUF_SZ);
+	CircBuffer* buf = make_rx(mem);
+	int i;
+	double t0, ns;
+
+	for (i = 0; i < WARMUP; i++) {
+		if (CircBufFull(buf) || (TCP_RX_BUF_SZ - AuCircBufSize(buf)) < TCP_MSS)
+			tcp_receive(buf, dst, RECV_SZ);
+		tcp_write_rx(buf, src, TCP_MSS);
+		if (AuCircBufSize(buf) >= RECV_SZ)
+			tcp_receive(buf, dst, RECV_SZ);
+		sink += dst[0];
+	}
+	AuCircBufFree(buf);
+	buf = make_rx(mem);
+
+	t0 = now_ns();
+	for (i = 0; i < iters; i++) {
+		int w, r = 0;
+		if (CircBufFull(buf) || (TCP_RX_BUF_SZ - AuCircBufSize(buf)) < TCP_MSS)
+			tcp_receive(buf, dst, RECV_SZ);
+		w = tcp_write_rx(buf, src, TCP_MSS);
+		if (AuCircBufSize(buf) >= RECV_SZ)
+			r = tcp_receive(buf, dst, RECV_SZ);
+		sink += dst[0] + (unsigned)w + (unsigned)r;
+	}
+	while (!CircBufEmpty(buf))
+		tcp_receive(buf, dst, RECV_SZ);
+	ns = (now_ns() - t0) / iters;
+	AuCircBufFree(buf);
+	free(mem);
+	return ns;
+}
+
+int main(void) {
+	int sizes[] = { 64, 256, 512, 1024, 1460 };
+	int s;
+	double tcp_ns;
+
+	for (s = 0; s < TCP_RX_BUF_SZ; s++)
+		src[s] = (uint8_t)(s * 131u + 17u);
+
+#ifdef TCP_USES_BULK
+	printf("tcp_rx: AuCircBufWrite/Read (bulk)\n");
+#else
+	printf("tcp_rx: AuCircBufPut/Get (byte)\n");
+#endif
+	printf("ring=%d  mss=%d  recv=%d  iters=%d\n\n",
+	       TCP_RX_BUF_SZ, TCP_MSS, RECV_SZ, ITERATIONS);
+
+	if (run_correctness())
+		return 1;
+
+	printf("\n%-22s  %s\n", "Case", "ns/op");
+	printf("----------------------  ----------\n");
+	for (s = 0; s < (int)(sizeof(sizes) / sizeof(sizes[0])); s++) {
+		char label[32];
+		snprintf(label, sizeof(label), "aligned %dB", sizes[s]);
+		printf("%-22s  %10.1f\n", label, time_aligned((size_t)sizes[s], ITERATIONS));
+	}
+	printf("\n");
+	for (s = 0; s < (int)(sizeof(sizes) / sizeof(sizes[0])); s++) {
+		char label[32];
+		snprintf(label, sizeof(label), "wrap %dB", sizes[s]);
+		printf("%-22s  %10.1f\n", label, time_wrap((size_t)sizes[s], ITERATIONS));
+	}
+	tcp_ns = time_tcp_like(ITERATIONS);
+	printf("\n%-22s  %10.1f\n", "tcp-like 1460/4096", tcp_ns);
+	printf("\nRESULT tcp_like_ns=%.1f\n", tcp_ns);
+	(void)sink;
+	return 0;
+}

--- a/Tests/bench_compare.sh
+++ b/Tests/bench_compare.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Compile each tree's circbuf.c and drive the TCP RX path.
+#
+# Usage:
+#   bash Tests/bench_compare.sh
+#   bash Tests/bench_compare.sh HEAD~1 HEAD
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+CC="${CC:-clang}"
+CFLAGS="-O2 -Wall -Wextra"
+PREV_REV="${1:-HEAD~1}"
+CURR_REV="${2:-HEAD}"
+PREV_WT=""
+CURR_WT=""
+
+cleanup() {
+	if [[ -n "$PREV_WT" ]]; then
+		git -C "$REPO" worktree remove --force "$PREV_WT" >/dev/null 2>&1 || true
+		rm -rf "$PREV_WT"
+	fi
+	if [[ -n "$CURR_WT" ]]; then
+		git -C "$REPO" worktree remove --force "$CURR_WT" >/dev/null 2>&1 || true
+		rm -rf "$CURR_WT"
+	fi
+}
+trap cleanup EXIT
+
+checkout_rev() {
+	local rev="$1"
+	local wt
+	wt="$(mktemp -d /tmp/xeneva-bench-XXXXXX)"
+	git -C "$REPO" worktree add --detach "$wt" "$rev" >/dev/null
+	echo "$wt"
+}
+
+tcp_uses_bulk() {
+	grep -q 'AuCircBufWrite' "$1/KernelAA64/Net/tcp.c"
+}
+
+rx_buf_sz() {
+	local n
+	n="$(sed -n 's/^#define TCP_RX_BUF_SZ \([0-9][0-9]*\).*/\1/p' "$1/BaseHdr/Net/tcp.h" | head -1)"
+	echo "${n:-16384}"
+}
+
+run_rev() {
+	local label="$1"
+	local rev="$2"
+	local wt="$3"
+	local tmp flags sz out
+	tmp="$(mktemp -d /tmp/xeneva-bench-build-XXXXXX)"
+	flags=""
+	if tcp_uses_bulk "$wt"; then
+		flags="-DTCP_USES_BULK"
+		echo "=== $label $(git -C "$REPO" rev-parse --short "$rev")  [tcp: bulk] ==="
+	else
+		echo "=== $label $(git -C "$REPO" rev-parse --short "$rev")  [tcp: byte] ==="
+	fi
+	sz="$(rx_buf_sz "$wt")"
+	$CC $CFLAGS -iquote "$wt/BaseHdr" $flags -DTCP_RX_BUF_SZ="$sz" \
+		-c "$REPO/Tests/bench_circbuf.c" -o "$tmp/bench.o"
+	$CC $CFLAGS -I "$wt/BaseHdr" \
+		-Wno-incompatible-library-redeclaration \
+		-Wno-incompatible-pointer-types-discards-qualifiers \
+		-c "$wt/KernelAA64/circbuf.c" -o "$tmp/circbuf.o"
+	out="$tmp/bench"
+	$CC $CFLAGS -o "$out" "$tmp/bench.o" "$tmp/circbuf.o" -lrt
+	"$out"
+	echo ""
+	rm -rf "$tmp"
+}
+
+echo "clang: $($CC --version | head -1)"
+echo "checkout $PREV_REV -> worktree, then $CURR_REV -> worktree"
+echo ""
+
+PREV_WT="$(checkout_rev "$PREV_REV")"
+CURR_WT="$(checkout_rev "$CURR_REV")"
+
+run_rev "PREV" "$PREV_REV" "$PREV_WT"
+run_rev "CURR" "$CURR_REV" "$CURR_WT"


### PR DESCRIPTION
## Summary
Cut TCP RX copy cost by replacing per-byte circbuf put/get with bulk `memcpy`, and point CI at the LLVM/Clang AArch64 build instead of GCC and MSVC.

## Changes
### circbuf + TCP (aarch64)
- **Before:** Incoming segments and `recv()` copied the RX ring one byte at a time (`AuCircBufPut` / `AuCircBufGet`) — pointer math and a call per byte (~12k calls for a 1460-byte MSS).
- **What:** Added `AuCircBufWrite` / `AuCircBufRead` (1–2 `memcpy`s, including wrap). `TCPWriteRx` and `AuTCPReceive` use them. Host bench: `Tests/bench_compare.sh` (HEAD~1 vs HEAD, clang) — tcp-like 1460/4096 ~10µs → ~36ns.
- **Why:** The byte loop was the hot copy on every segment and every recv; bulk copy keeps the same ring semantics.

### GitHub Actions
- **Before:** CI built BootAA64/KernelAA64 with `gcc-aarch64-linux-gnu` and `Aurora.sln` with MSVC.
- **What:** One `ubuntu-latest` job: `clang`/`lld`, shallow gnu-efi clone, `make -C BootAA64 llvm` and `make -C KernelAA64 llvm`. Checkout v4.
- **Why:** That is the aarch64 toolchain you actually use; GCC and MSVC CI were not covering it.

## Compatibility
- [x] Existing functionality is unchanged (or breaking changes are explicitly documented).
- [x] MSVC/Windows build toolchain remains fully compatible.
- [x] GCC/Linux build toolchain remains fully compatible.
- [x] No regression in bootloader, kernel, or user-space runtime logic.

Byte put/get remain. New circbuf APIs are aarch64-only; x86 does not call them. MSVC/GCC trees are unchanged; they are just no longer built on CI.

## Related